### PR TITLE
Verify source manifest and refuse to publish regressed or stale data

### DIFF
--- a/build.py
+++ b/build.py
@@ -238,11 +238,43 @@ class CVESiteBuilder:
             return True
 
         except ImportError as e:
+            # httpx is optional. Previously this returned True, so a refresh
+            # reported success in about a second having downloaded nothing.
+            # Fall back to the synchronous downloader, which uses requests.
             logger.warning(f"⚠️  Async downloads unavailable: {e}")
-            logger.info("   Install httpx for parallel downloads: pip install httpx")
-            return True  # Continue with existing cache
+            logger.info("   Falling back to sequential downloads (pip install httpx to parallelise)")
+            return self.refresh_data_sync(force=force, manifest=source_manifest)
         except Exception as e:
             logger.error(f"❌ Data refresh failed: {e}")
+            return False
+
+    def refresh_data_sync(self, force: bool = False, manifest: dict[str, Any] | None = None) -> bool:
+        """Sequential fallback for when httpx is unavailable.
+
+        Slower than the async path but functionally equivalent, and honest: it
+        actually downloads, and reports failure when it fails.
+        """
+        from download_cve_data import CVEDataDownloader
+
+        downloader = CVEDataDownloader(cache_dir=self.cache_dir, quiet=self.quiet)
+        try:
+            # Covers nvd.json plus the CNA mapping files, and verifies the
+            # snapshot against the manifest.
+            downloader.download_data(force=force, manifest=manifest)
+            downloader.download_cna_mapping_files()
+
+            if downloader.download_epss_data(force=force):
+                downloader.parse_epss_csv()
+            if downloader.download_kev_data(force=force):
+                downloader.parse_kev_json()
+
+            if manifest is not None:
+                downloader.persist_accepted_manifest(manifest)
+
+            self.print_verbose("✅ Data refresh complete (sequential)")
+            return True
+        except Exception as e:
+            logger.error(f"❌ Sequential data refresh failed: {e}")
             return False
 
     def clean_build(self) -> None:

--- a/build.py
+++ b/build.py
@@ -56,6 +56,10 @@ def default_command(
         bool, typer.Option("--force-refresh", "-f", help="Force re-download even if cache is valid")
     ] = False,
     validate_flag: Annotated[bool, typer.Option("--validate", help="Validate data consistency after build")] = False,
+    accept_baseline: Annotated[
+        bool,
+        typer.Option("--accept-baseline", help="Skip the source-manifest regression check"),
+    ] = False,
     log_level: Annotated[str, typer.Option("--log-level", help="Logging level (DEBUG, INFO, WARNING, ERROR)")] = "INFO",
 ) -> None:
     """Default command - runs build if no subcommand specified.
@@ -74,6 +78,7 @@ def default_command(
         quiet=quiet,
         refresh_data=refresh_data,
         force_refresh=force_refresh,
+        accept_baseline=accept_baseline,
         validate=validate_flag,
         log_level=log_level,
     )
@@ -136,7 +141,29 @@ class CVESiteBuilder:
             return f"{num / 1000:.1f}K"
         return str(num)
 
-    def refresh_data(self, force: bool = False) -> bool:
+    def verify_source_manifest(self, accept_baseline: bool = False) -> dict[str, Any] | None:
+        """Run the producer-manifest gates before any bulk download.
+
+        Returns the manifest when one is available, else None. Raises when the
+        producer reports a degraded run or the snapshot has regressed against
+        the last one we accepted.
+        """
+        from download_cve_data import CVEDataDownloader
+
+        checker = CVEDataDownloader(cache_dir=self.cache_dir, quiet=self.quiet)
+        manifest = checker.fetch_source_manifest()
+        if manifest is None:
+            logger.warning("⚠️  Proceeding without manifest verification")
+            return None
+
+        if accept_baseline:
+            logger.warning("⚠️  --accept-baseline: skipping manifest regression check")
+        else:
+            checker.verify_manifest_healthy(manifest)
+            checker.verify_manifest_not_regressed(manifest, checker.fetch_baseline_manifest())
+        return manifest
+
+    def refresh_data(self, force: bool = False, accept_baseline: bool = False) -> bool:
         """Refresh CVE data from all sources using async parallel downloads.
 
         Downloads data from 5 sources in parallel (~3x faster than sequential):
@@ -154,12 +181,25 @@ class CVESiteBuilder:
         """
         self.print_verbose("📥 Refreshing CVE data from all sources...")
 
+        # The async path downloads nvd.json directly, bypassing the manifest
+        # gate in CVEDataDownloader.ensure_data_available(). Run the same checks
+        # here so a manual --refresh-data cannot skip verification.
+        source_manifest = self.verify_source_manifest(accept_baseline=accept_baseline)
+
         try:
             downloader = AsyncCVEDownloader(
                 cache_dir=self.cache_dir,
                 quiet=self.quiet,
             )
             results = downloader.download_all_sync(force=force)
+
+            # Record the manifest only after the download it describes succeeded.
+            if source_manifest is not None:
+                from download_cve_data import CVEDataDownloader
+
+                CVEDataDownloader(
+                    cache_dir=self.cache_dir, quiet=self.quiet
+                ).persist_accepted_manifest(source_manifest)
 
             # Parse supplemental data
             downloader.parse_epss()
@@ -1033,12 +1073,15 @@ class CVESiteBuilder:
 
         self.print_always("✅ HTML pages generated successfully")
 
-    def build_site(self, refresh_data: bool = False, force_refresh: bool = False) -> bool:
+    def build_site(
+        self, refresh_data: bool = False, force_refresh: bool = False, accept_baseline: bool = False
+    ) -> bool:
         """Main build function - orchestrates the entire build process
 
         Args:
             refresh_data: If True, refresh CVE data before building
             force_refresh: If True, force re-download even if cache is valid
+            accept_baseline: If True, skip the manifest regression check
         """
         self.print_always("\n🏗️  Starting CVE.ICU site build...")
         if not self.quiet:
@@ -1049,7 +1092,9 @@ class CVESiteBuilder:
 
         try:
             # Step 0: Optionally refresh data from upstream sources
-            if refresh_data and not self.refresh_data(force=force_refresh):
+            if refresh_data and not self.refresh_data(
+                force=force_refresh, accept_baseline=accept_baseline
+            ):
                 logger.error("❌ Data refresh failed, cannot continue build")
                 return False
 
@@ -1065,6 +1110,12 @@ class CVESiteBuilder:
             if not all_year_data:
                 logger.error("❌ No year data generated, cannot continue build")
                 return False
+
+            # Step 3.4: Republish the accepted source manifest with the site so
+            # the next build can use it as its regression baseline. Keeping the
+            # baseline on the live site (rather than in the repo) is what lets
+            # the scheduled workflow stop committing web/ back to main.
+            self.publish_source_manifest()
 
             # Step 3.5: Guard against truncated/incomplete upstream feeds.
             # A complete historical year that comes back with zero CVEs means the
@@ -1117,6 +1168,47 @@ class CVESiteBuilder:
             if staged_web_dir.exists():
                 shutil.rmtree(staged_web_dir, ignore_errors=True)
 
+    def publish_source_manifest(self) -> None:
+        """Copy the accepted source manifest into the site output.
+
+        Published at /data/source_manifest.json, which is where the downloader
+        looks for its regression baseline on the next run. Absent manifest is
+        not fatal: the producer may not have published one, in which case the
+        next run simply has no baseline to compare against.
+        """
+        manifest_src = self.cache_dir / "source_manifest.json"
+        cache_info_src = self.cache_dir / "cache_info.json"
+        if not manifest_src.exists():
+            self.print_verbose("  ⚠️  No accepted source manifest to publish")
+            return
+
+        # Only publish a manifest that describes the snapshot we actually built
+        # from. The cached manifest survives across runs, so republishing it
+        # blindly could advertise a baseline for data this build never used,
+        # which would then wrongly gate every future run.
+        try:
+            with open(manifest_src) as f:
+                manifest = json.load(f)
+            with open(cache_info_src) as f:
+                cache_info = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(f"  ⚠️  Could not verify manifest against cache info: {e}")
+            return
+
+        manifest_run = manifest.get("last_run_iso")
+        cached_run = cache_info.get("source_last_run")
+        if manifest_run != cached_run:
+            logger.warning(
+                f"  ⚠️  Not publishing source manifest: it describes run "
+                f"{manifest_run}, but the cached snapshot came from {cached_run}"
+            )
+            return
+
+        destination = self.data_dir / "source_manifest.json"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(manifest_src, destination)
+        self.print_verbose(f"  ✅ Published source_manifest.json (run {manifest_run})")
+
     def verify_historical_year_coverage(self, all_year_data: list[dict[str, Any]]) -> None:
         """Fail the build if any complete historical year has zero CVEs.
 
@@ -1165,6 +1257,14 @@ def build(
     validate: Annotated[
         bool, typer.Option("--validate", help="Validate data counting consistency after build")
     ] = False,
+    accept_baseline: Annotated[
+        bool,
+        typer.Option(
+            "--accept-baseline",
+            help="Skip the source-manifest regression check. Use only when the producer "
+            "has legitimately published a smaller snapshot and it has been confirmed.",
+        ),
+    ] = False,
     log_level: Annotated[str, typer.Option("--log-level", help="Logging level")] = "INFO",
 ) -> None:
     """Build the CVE.ICU static site.
@@ -1195,6 +1295,7 @@ def build(
     success = builder.build_site(
         refresh_data=refresh_data,
         force_refresh=force_refresh,
+        accept_baseline=accept_baseline,
     )
 
     if success and validate:

--- a/build.py
+++ b/build.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import jinja2
+import requests
 
 
 # Add data folder to path for imports
@@ -91,6 +92,15 @@ class CVESiteBuilder:
         self.quiet: bool = quiet or os.getenv("CVE_BUILD_QUIET", "").lower() in ("1", "true", "yes")
         self.current_year: int = datetime.now().year
         self.available_years: list[int] = list(range(1999, self.current_year + 1))
+
+        # Regression guard configuration. See verify_no_regression() for how
+        # the allowance was derived; it is deliberately much tighter than a
+        # percentage band would be.
+        self.published_totals_url: str = "https://cve.icu/data/cve_all.json"
+        self.regression_allowance: int = 10
+        # A 3-hourly build should never be running on data a full day old.
+        self.max_data_age_hours: float = 24.0
+        self.accept_baseline: bool = False
         self.base_dir: Path = Path(__file__).parent
         self.output_root_dir: Path = self.base_dir / "web"
         self.templates_dir: Path = self.base_dir / "templates"
@@ -757,6 +767,7 @@ class CVESiteBuilder:
 
         homepage_summary = {
             "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            **self.source_provenance(),
             "current_year": self.current_year,
             "yearly_summary": {
                 "years": yearly_summary_years,
@@ -832,6 +843,7 @@ class CVESiteBuilder:
         """Write a minimal data_quality.json payload when detailed analysis cannot be generated."""
         fallback_data = {
             "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            **self.source_provenance(),
             "status": "fallback",
             "reason": reason,
             "stats": {
@@ -897,6 +909,7 @@ class CVESiteBuilder:
 
         cve_all_data = {
             "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            **self.source_provenance(),
             "total_cves": total_cves,
             "years_covered": years_with_data,
             "current_year": self.current_year,
@@ -930,7 +943,11 @@ class CVESiteBuilder:
             return
 
         # Build summary structure with everything years.html needs
-        summary = {"generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"), "years": {}}
+        summary = {
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            **self.source_provenance(),
+            "years": {},
+        }
 
         for year_data in sorted(all_year_data, key=lambda x: x.get("year", 0)):
             year = year_data.get("year")
@@ -1092,6 +1109,8 @@ class CVESiteBuilder:
 
         try:
             # Step 0: Optionally refresh data from upstream sources
+            self.accept_baseline = accept_baseline
+
             if refresh_data and not self.refresh_data(
                 force=force_refresh, accept_baseline=accept_baseline
             ):
@@ -1122,6 +1141,13 @@ class CVESiteBuilder:
             # source feed was partial when downloaded. Fail loudly here so bad
             # data is never published or committed.
             self.verify_historical_year_coverage(all_year_data)
+
+            # Step 3.6: Refuse to publish data older than the freshness limit,
+            # and refuse counts that fall below what is already live. These are
+            # independent of the producer-side manifest checks: they catch our
+            # own analysis regressions, which the producer cannot see.
+            self.verify_data_freshness()
+            self.verify_no_regression(all_year_data)
 
             # Step 4: Generate combined analysis JSON files
             combined_analysis = self.generate_combined_analysis_json(all_year_data)
@@ -1208,6 +1234,152 @@ class CVESiteBuilder:
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(manifest_src, destination)
         self.print_verbose(f"  ✅ Published source_manifest.json (run {manifest_run})")
+
+    def fetch_published_totals(self) -> dict[str, Any] | None:
+        """Fetch the currently published cve_all.json to use as a baseline.
+
+        Read from the live site rather than the repo so the check survives the
+        scheduled workflow no longer committing web/ back to main.
+        """
+        try:
+            response = requests.get(self.published_totals_url, timeout=30)
+            if response.status_code == 404:
+                logger.info("  📊 No published totals yet (first run)")
+                return None
+            response.raise_for_status()
+            published = response.json()
+        except (requests.RequestException, ValueError, json.JSONDecodeError) as e:
+            logger.warning(f"  ⚠️  Could not fetch published totals: {e}")
+            return None
+
+        if not isinstance(published, dict) or "total_cves" not in published:
+            logger.warning("  ⚠️  Published totals are malformed; ignoring")
+            return None
+        return published
+
+    def verify_no_regression(self, all_year_data: list[dict[str, Any]]) -> None:
+        """Fail the build if our own counts fall below what is already published.
+
+        This is deliberately independent of the source-manifest check in the
+        downloader. That one catches a bad snapshot from the producer; this one
+        catches a bug in our own analysis code, which the producer cannot see.
+
+        Keying: both sides here are OUR outputs, bucketed by publication date.
+        Never compare these to the manifest's year_counts, which are keyed by
+        CVE-ID year and are a different partition of the same data.
+
+        Thresholds are tight on purpose. Sweeping the 400 builds published
+        between 2026-06-26 and 2026-08-17 showed no legitimate run ever reduced
+        the site-wide total by more than 10, because the handful of genuine CVE
+        withdrawals in any window are outweighed by same-window additions. A
+        10-CVE allowance caught 15 of the 17 known bad builds with no false
+        positives; a 0.1% band, which is the intuitive choice, caught only 7.
+
+        Raises:
+            RuntimeError: on a material regression in the total or any closed year.
+        """
+        if self.accept_baseline:
+            logger.warning("  ⚠️  --accept-baseline: skipping published-totals regression check")
+            return
+
+        published = self.fetch_published_totals()
+        if published is None:
+            logger.info("  📊 No baseline available; skipping regression check")
+            return
+
+        problems: list[str] = []
+
+        prev_total = published.get("total_cves", 0)
+        new_total = sum(d.get("total_cves", 0) for d in all_year_data)
+        if new_total < prev_total - self.regression_allowance:
+            problems.append(
+                f"total {prev_total:,} -> {new_total:,} ({new_total - prev_total:,}, "
+                f"allowance {self.regression_allowance})"
+            )
+
+        new_years = {int(d["year"]): d.get("total_cves", 0) for d in all_year_data if "year" in d}
+        for entry in published.get("yearly_trend", []):
+            year = int(entry.get("year", 0))
+            # The current year is still accumulating, so only closed years are
+            # expected to hold steady.
+            if year >= self.current_year:
+                continue
+            prev_count = entry.get("count", 0)
+            new_count = new_years.get(year, 0)
+            if new_count < prev_count - self.regression_allowance:
+                problems.append(f"year {year} {prev_count:,} -> {new_count:,} ({new_count - prev_count:,})")
+
+        if problems:
+            raise RuntimeError(
+                "Counts regressed against the published site:\n  "
+                + "\n  ".join(problems)
+                + "\nThis usually means a bad upstream snapshot or an analysis "
+                "regression. Aborting before publish. Re-run with "
+                "--accept-baseline if the decrease has been confirmed as real."
+            )
+
+        logger.info(f"    ✅ No regression against published totals ({prev_total:,} -> {new_total:,})")
+
+    def verify_data_freshness(self) -> None:
+        """Warn when the snapshot behind this build is old.
+
+        generated_at records when the build ran, which says nothing about how
+        old the underlying data is. This surfaces the difference rather than
+        letting a stale cache be published under a fresh timestamp.
+        """
+        info = self.source_provenance()
+        age_hours = info.get("data_age_hours")
+        if age_hours is None:
+            logger.warning("  ⚠️  Could not determine data age from cache info")
+            return
+
+        if age_hours > self.max_data_age_hours:
+            raise RuntimeError(
+                f"Source snapshot is {age_hours:.1f}h old, exceeding the "
+                f"{self.max_data_age_hours}h limit (downloaded "
+                f"{info.get('data_as_of')}). Refusing to publish stale data as fresh."
+            )
+        logger.info(f"    ✅ Source snapshot is {age_hours:.1f}h old")
+
+    @cache  # noqa: B019 - per-build instance, process is short-lived
+    def source_provenance(self) -> dict[str, Any]:
+        """Provenance of the snapshot this build is using.
+
+        Separate from generated_at, which is build time. Embedded in every
+        output so the site can show how old the data actually is.
+        """
+        cache_info_file = self.cache_dir / "cache_info.json"
+        provenance: dict[str, Any] = {
+            "data_as_of": None,
+            "data_age_hours": None,
+            "source_last_run": None,
+            "source_cve_count": None,
+        }
+        try:
+            with open(cache_info_file) as f:
+                info = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(f"  ⚠️  Could not read cache info: {e}")
+            return provenance
+
+        provenance["source_last_run"] = info.get("source_last_run")
+        provenance["source_cve_count"] = info.get("source_cve_count")
+
+        download_time = info.get("download_time")
+        if download_time:
+            try:
+                stamp = datetime.fromisoformat(download_time)
+                # Older cache_info files carry a naive local timestamp.
+                if stamp.tzinfo is None:
+                    stamp = stamp.replace(tzinfo=UTC)
+                provenance["data_as_of"] = stamp.isoformat().replace("+00:00", "Z")
+                provenance["data_age_hours"] = round(
+                    (datetime.now(UTC) - stamp).total_seconds() / 3600, 1
+                )
+            except ValueError as e:
+                logger.warning(f"  ⚠️  Could not parse download_time {download_time!r}: {e}")
+
+        return provenance
 
     def verify_historical_year_coverage(self, all_year_data: list[dict[str, Any]]) -> None:
         """Fail the build if any complete historical year has zero CVEs.

--- a/build.py
+++ b/build.py
@@ -61,6 +61,9 @@ def default_command(
         bool,
         typer.Option("--accept-baseline", help="Skip the source-manifest regression check"),
     ] = False,
+    strict: Annotated[
+        bool, typer.Option("--strict", help="Treat data guards as fatal outside CI")
+    ] = False,
     log_level: Annotated[str, typer.Option("--log-level", help="Logging level (DEBUG, INFO, WARNING, ERROR)")] = "INFO",
 ) -> None:
     """Default command - runs build if no subcommand specified.
@@ -80,6 +83,7 @@ def default_command(
         refresh_data=refresh_data,
         force_refresh=force_refresh,
         accept_baseline=accept_baseline,
+        strict=strict,
         validate=validate_flag,
         log_level=log_level,
     )
@@ -101,6 +105,12 @@ class CVESiteBuilder:
         # A 3-hourly build should never be running on data a full day old.
         self.max_data_age_hours: float = 24.0
         self.accept_baseline: bool = False
+        # These guards exist to stop bad data being *published*. A local build
+        # publishes nothing, so blocking a developer working from a deliberately
+        # old cache is friction with no safety benefit. CI is the deploy path,
+        # so there they are fatal; locally they warn. --strict forces fatal
+        # anywhere, which is how you test the guard itself.
+        self.strict_data_guards: bool = bool(os.getenv("CI"))
         self.base_dir: Path = Path(__file__).parent
         self.output_root_dir: Path = self.base_dir / "web"
         self.templates_dir: Path = self.base_dir / "templates"
@@ -1091,7 +1101,11 @@ class CVESiteBuilder:
         self.print_always("✅ HTML pages generated successfully")
 
     def build_site(
-        self, refresh_data: bool = False, force_refresh: bool = False, accept_baseline: bool = False
+        self,
+        refresh_data: bool = False,
+        force_refresh: bool = False,
+        accept_baseline: bool = False,
+        strict: bool = False,
     ) -> bool:
         """Main build function - orchestrates the entire build process
 
@@ -1099,6 +1113,7 @@ class CVESiteBuilder:
             refresh_data: If True, refresh CVE data before building
             force_refresh: If True, force re-download even if cache is valid
             accept_baseline: If True, skip the manifest regression check
+            strict: If True, treat data guards as fatal even outside CI
         """
         self.print_always("\n🏗️  Starting CVE.ICU site build...")
         if not self.quiet:
@@ -1110,6 +1125,8 @@ class CVESiteBuilder:
         try:
             # Step 0: Optionally refresh data from upstream sources
             self.accept_baseline = accept_baseline
+            if strict:
+                self.strict_data_guards = True
 
             if refresh_data and not self.refresh_data(
                 force=force_refresh, accept_baseline=accept_baseline
@@ -1235,6 +1252,23 @@ class CVESiteBuilder:
         shutil.copy2(manifest_src, destination)
         self.print_verbose(f"  ✅ Published source_manifest.json (run {manifest_run})")
 
+    def enforce_data_guard(self, summary: str, detail: str, remedy: str) -> None:
+        """Fail the build in CI, warn locally.
+
+        Args:
+            summary: one-line statement of what is wrong.
+            detail: the specific numbers, shown in both modes.
+            remedy: what the developer should do about it.
+        """
+        if self.strict_data_guards:
+            raise RuntimeError(f"{summary}\n{detail}\n{remedy}")
+
+        logger.warning(f"  ⚠️  {summary}")
+        for line in detail.splitlines():
+            logger.warning(f"  ⚠️  {line}")
+        logger.warning(f"  ⚠️  {remedy}")
+        logger.warning("  ⚠️  Not fatal outside CI. Use --strict to make it fatal here.")
+
     def fetch_published_totals(self) -> dict[str, Any] | None:
         """Fetch the currently published cve_all.json to use as a baseline.
 
@@ -1310,13 +1344,14 @@ class CVESiteBuilder:
                 problems.append(f"year {year} {prev_count:,} -> {new_count:,} ({new_count - prev_count:,})")
 
         if problems:
-            raise RuntimeError(
-                "Counts regressed against the published site:\n  "
-                + "\n  ".join(problems)
-                + "\nThis usually means a bad upstream snapshot or an analysis "
-                "regression. Aborting before publish. Re-run with "
-                "--accept-baseline if the decrease has been confirmed as real."
+            self.enforce_data_guard(
+                "Counts regressed against the published site.",
+                "  " + "\n  ".join(problems),
+                "This usually means a bad upstream snapshot, an analysis regression, "
+                "or a stale local cache. Refresh with 'python build.py refresh --force', "
+                "or re-run with --accept-baseline if the decrease is confirmed as real.",
             )
+            return
 
         logger.info(f"    ✅ No regression against published totals ({prev_total:,} -> {new_total:,})")
 
@@ -1334,11 +1369,14 @@ class CVESiteBuilder:
             return
 
         if age_hours > self.max_data_age_hours:
-            raise RuntimeError(
-                f"Source snapshot is {age_hours:.1f}h old, exceeding the "
-                f"{self.max_data_age_hours}h limit (downloaded "
-                f"{info.get('data_as_of')}). Refusing to publish stale data as fresh."
+            self.enforce_data_guard(
+                f"Source snapshot is {age_hours:.1f}h old, over the "
+                f"{self.max_data_age_hours}h limit.",
+                f"  downloaded {info.get('data_as_of')}",
+                "Stale data must not be published under a fresh timestamp. "
+                "Refresh with 'python build.py refresh --force'.",
             )
+            return
         logger.info(f"    ✅ Source snapshot is {age_hours:.1f}h old")
 
     @cache  # noqa: B019 - per-build instance, process is short-lived
@@ -1437,6 +1475,14 @@ def build(
             "has legitimately published a smaller snapshot and it has been confirmed.",
         ),
     ] = False,
+    strict: Annotated[
+        bool,
+        typer.Option(
+            "--strict",
+            help="Treat data freshness and regression guards as fatal outside CI "
+            "(they are always fatal in CI).",
+        ),
+    ] = False,
     log_level: Annotated[str, typer.Option("--log-level", help="Logging level")] = "INFO",
 ) -> None:
     """Build the CVE.ICU static site.
@@ -1468,6 +1514,7 @@ def build(
         refresh_data=refresh_data,
         force_refresh=force_refresh,
         accept_baseline=accept_baseline,
+        strict=strict,
     )
 
     if success and validate:

--- a/data/download_cve_data.py
+++ b/data/download_cve_data.py
@@ -10,7 +10,7 @@ import csv
 import gzip
 import hashlib
 import json
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -70,6 +70,23 @@ class CVEDataDownloader:
         self.cache_file: Path = self.cache_dir / "nvd.json"
         self.cache_info_file: Path = self.cache_dir / "cache_info.json"
         self.cache_duration: timedelta = timedelta(hours=4)  # Cache for 4 hours to match build schedule
+
+        # Producer-published manifest describing the snapshot behind nvd.json.
+        # Small (~2KB), no-cache, and written *after* the data object, so a
+        # manifest that names a snapshot implies that snapshot is fully uploaded.
+        self.manifest_url: str = "https://nvd.handsonhacking.org/metadata.json"
+        # The last manifest we accepted, republished with the site so the next
+        # build has a baseline without needing repo state. See docs in
+        # verify_manifest_not_regressed().
+        self.manifest_baseline_url: str = "https://cve.icu/data/source_manifest.json"
+        self.manifest_file: Path = self.cache_dir / "source_manifest.json"
+        # Producer reports its own completeness_ratio. This is a catastrophe
+        # backstop only, NOT the primary defence: the regression check against
+        # the last accepted manifest is. Calibration caveat: the only healthy
+        # value observed so far is 0.9992, so the normal variance of this field
+        # is unknown and the threshold is deliberately loose. Tighten it once
+        # there is a distribution to set it from, rather than from one sample.
+        self.min_completeness_ratio: float = 0.995
         
         # CNA mapping files for proper name resolution
         self.cna_list_url: str = "https://raw.githubusercontent.com/CVEProject/cve-website/dev/src/assets/data/CNAsList.json"
@@ -105,7 +122,11 @@ class CVEDataDownloader:
             cache_info = self._data_reader.read_json(self.cache_info_file)
             
             cache_time = datetime.fromisoformat(cache_info['download_time'])
-            if datetime.now() - cache_time > self.cache_duration:
+            # Older cache_info files carry a naive local timestamp; treat those
+            # as UTC so the comparison below stays valid across the format change.
+            if cache_time.tzinfo is None:
+                cache_time = cache_time.replace(tzinfo=UTC)
+            if datetime.now(UTC) - cache_time > self.cache_duration:
                 if not self.quiet:
                     logger.info(f"⏰ Cache expired (older than {self.cache_duration})")
                 return False
@@ -119,8 +140,15 @@ class CVEDataDownloader:
                 logger.warning(f"⚠️  Cache info corrupted: {e}")
             return False
     
-    def download_data(self, force: bool = False) -> Path:
-        """Download CVE data from NVD source"""
+    def download_data(self, force: bool = False, manifest: dict[str, Any] | None = None) -> Path:
+        """Download CVE data from NVD source.
+
+        Args:
+            force: bypass the local cache-validity check.
+            manifest: producer manifest for this snapshot. When it carries
+                'bytes' or 'sha256', the downloaded object is verified against
+                them before being accepted.
+        """
         if not force and self.is_cache_valid():
             if not self.quiet:
                 logger.info("📋 Using cached data")
@@ -151,18 +179,36 @@ class CVEDataDownloader:
                             progress = (downloaded_size / total_size) * 100
                             logger.debug(f"  📥 Downloaded {downloaded_size // (1024*1024)}MB / {total_size // (1024*1024)}MB ({progress:.1f}%)")
             
+            # A dropped connection previously produced a short file that was
+            # written and reported as a success. content-length is advisory,
+            # but when the server sends one, a mismatch means truncation.
+            if total_size and downloaded_size != total_size:
+                raise OSError(
+                    f"Truncated download: received {downloaded_size:,} of "
+                    f"{total_size:,} bytes declared by content-length"
+                )
+
             # Write using data writer
             self._data_writer.write_bytes(self.cache_file, b''.join(chunks))
             
+            # Verify the object against the producer's manifest before we
+            # treat it as usable. Raises on any mismatch.
+            self.verify_download_against_manifest(manifest, downloaded_size)
+
             # Calculate file hash for integrity check
-            file_hash = self.calculate_file_hash(self.cache_file)
+            file_hash = self.calculate_file_hash_streaming(self.cache_file)
             
             # Save cache info using data writer
             cache_info = {
-                'download_time': datetime.now().isoformat(),
+                # UTC: this value is compared against build time to derive data
+                # age, and a naive local timestamp made that comparison wrong.
+                'download_time': datetime.now(UTC).isoformat(),
                 'file_size': downloaded_size,
                 'file_hash': file_hash,
-                'source_url': self.nvd_url
+                'source_url': self.nvd_url,
+                'source_last_run': (manifest or {}).get('last_run_iso'),
+                'source_cve_count': (manifest or {}).get('cve_count'),
+                'source_commit_sha': (manifest or {}).get('commit_sha'),
             }
             
             self._data_writer.write_json(self.cache_info_file, cache_info)
@@ -214,6 +260,198 @@ class CVEDataDownloader:
         except (OSError, json.JSONDecodeError) as e:
             logger.warning(f"⚠️  Warning: File or JSON error downloading CNA files: {e}")
     
+    # ------------------------------------------------------------------
+    # Source manifest handling
+    #
+    # The producer publishes metadata.json alongside nvd.json describing the
+    # snapshot it just uploaded. Checking it before pulling the ~1.8GB object
+    # turns several count heuristics into exact checks, and catches a short
+    # snapshot before we spend the bandwidth on it.
+    #
+    # Keying note: manifest year_counts are keyed by CVE-ID year, while this
+    # site buckets by publication date. The two are different partitions of
+    # the same data (year 1999 is 1,579 by ID and 923 by publication date), so
+    # manifest counts are only ever compared to *previous manifest* counts,
+    # never to our own per-year outputs.
+    # ------------------------------------------------------------------
+
+    def fetch_source_manifest(self) -> dict[str, Any] | None:
+        """Fetch the producer's manifest for the current snapshot.
+
+        Returns None when the manifest cannot be retrieved or parsed, which
+        callers treat as "unverified" rather than as a failure, so a producer
+        that has not yet deployed the manifest does not break the build.
+        """
+        try:
+            response = self._http_client.get(self.manifest_url, timeout=30)
+            status = getattr(response, "status_code", 200)
+            if status >= 400:
+                logger.warning(f"⚠️  Source manifest returned HTTP {status}")
+                return None
+            manifest = response.json()
+        except (requests.RequestException, ValueError, json.JSONDecodeError, OSError) as e:
+            logger.warning(f"⚠️  Could not fetch source manifest: {e}")
+            return None
+
+        if not isinstance(manifest, dict) or "cve_count" not in manifest:
+            logger.warning("⚠️  Source manifest is malformed; ignoring")
+            return None
+
+        logger.info(
+            f"📄 Source manifest: {manifest['cve_count']:,} CVEs, "
+            f"run {manifest.get('last_run_iso', 'unknown')}"
+        )
+        return manifest
+
+    def fetch_baseline_manifest(self) -> dict[str, Any] | None:
+        """Fetch the last manifest we accepted, as republished with the site."""
+        try:
+            response = self._http_client.get(self.manifest_baseline_url, timeout=30)
+            status = getattr(response, "status_code", 200)
+            if status == 404:
+                logger.info("📄 No published baseline manifest yet (first run)")
+                return None
+            if status >= 400:
+                logger.warning(f"⚠️  Baseline manifest returned HTTP {status}")
+                return None
+            baseline = response.json()
+        except (requests.RequestException, ValueError, json.JSONDecodeError, OSError) as e:
+            logger.warning(f"⚠️  Could not fetch baseline manifest: {e}")
+            return None
+
+        if not isinstance(baseline, dict) or "cve_count" not in baseline:
+            logger.warning("⚠️  Baseline manifest is malformed; ignoring")
+            return None
+        return baseline
+
+    def verify_manifest_healthy(self, manifest: dict[str, Any]) -> None:
+        """Reject a snapshot the producer itself reports as incomplete.
+
+        Raises:
+            ValueError: if the run was degraded, fell back to the API for any
+                year, or came in under the completeness threshold.
+        """
+        if manifest.get("degraded"):
+            raise ValueError(
+                f"Producer reported a degraded run "
+                f"(last_run_iso={manifest.get('last_run_iso')}). Refusing to ingest."
+            )
+
+        years_via_api = manifest.get("years_via_api") or []
+        if years_via_api:
+            raise ValueError(
+                f"Producer fell back to the REST API for year(s) {years_via_api}. "
+                "That fallback drops records whose CVE-ID year and publication "
+                "year differ. Refusing to ingest."
+            )
+
+        ratio = manifest.get("completeness_ratio")
+        if ratio is not None and ratio < self.min_completeness_ratio:
+            raise ValueError(
+                f"Producer completeness_ratio {ratio} is below "
+                f"{self.min_completeness_ratio} "
+                f"({manifest.get('cve_count'):,} of an expected "
+                f"{manifest.get('expected_total')}). Refusing to ingest."
+            )
+
+    def verify_manifest_not_regressed(
+        self,
+        manifest: dict[str, Any],
+        baseline: dict[str, Any] | None,
+    ) -> None:
+        """Reject a snapshot smaller than the last one we accepted.
+
+        Both sides are CVE-ID keyed, so this is a like-for-like comparison.
+        CVEs are withdrawn occasionally, but a genuine withdrawal is a handful
+        of records; every regression observed in this feed's history has been a
+        producer-side fault of hundreds to thousands.
+
+        Raises:
+            ValueError: on any decrease in the total or in any per-year count.
+        """
+        if baseline is None:
+            logger.info("📄 No baseline to compare against; accepting manifest")
+            return
+
+        problems: list[str] = []
+
+        prev_total = baseline.get("cve_count", 0)
+        new_total = manifest.get("cve_count", 0)
+        if new_total < prev_total:
+            problems.append(f"total {prev_total:,} -> {new_total:,} ({new_total - prev_total:,})")
+
+        new_years = manifest.get("year_counts") or {}
+        for year, prev_count in sorted((baseline.get("year_counts") or {}).items()):
+            new_count = new_years.get(year, 0)
+            if new_count < prev_count:
+                problems.append(f"year {year} {prev_count:,} -> {new_count:,} ({new_count - prev_count:,})")
+
+        if problems:
+            raise ValueError(
+                "Source manifest regressed against the last accepted snapshot:\n  "
+                + "\n  ".join(problems)
+                + "\nRefusing to ingest. Re-run once the producer publishes a "
+                "complete snapshot, or pass --accept-baseline to override."
+            )
+
+        logger.info(f"✅ Manifest not regressed (total {prev_total:,} -> {new_total:,})")
+
+    def verify_download_against_manifest(
+        self,
+        manifest: dict[str, Any] | None,
+        downloaded_size: int,
+    ) -> None:
+        """Verify the downloaded object against the manifest's size and digest.
+
+        Both fields are optional: they appear only from the first producer run
+        after the integrity work landed, so their absence is logged, not fatal.
+
+        Raises:
+            OSError: on a size or digest mismatch.
+        """
+        if not manifest:
+            return
+
+        expected_bytes = manifest.get("bytes")
+        if expected_bytes is None:
+            logger.warning("⚠️  Manifest has no 'bytes' field; skipping size verification")
+        elif downloaded_size != expected_bytes:
+            raise OSError(
+                f"Size mismatch: downloaded {downloaded_size:,} bytes, "
+                f"manifest declares {expected_bytes:,}. Snapshot is incomplete."
+            )
+        else:
+            logger.info(f"✅ Size verified against manifest ({downloaded_size:,} bytes)")
+
+        expected_sha = manifest.get("sha256")
+        if expected_sha is None:
+            logger.warning("⚠️  Manifest has no 'sha256' field; skipping digest verification")
+            return
+
+        actual_sha = self.calculate_file_hash_streaming(self.cache_file)
+        if actual_sha != expected_sha:
+            raise OSError(
+                f"SHA-256 mismatch: computed {actual_sha}, manifest declares {expected_sha}."
+            )
+        logger.info("✅ SHA-256 verified against manifest")
+
+    def persist_accepted_manifest(self, manifest: dict[str, Any]) -> None:
+        """Record the manifest we accepted so the site can republish it."""
+        self._data_writer.write_json(self.manifest_file, manifest)
+        logger.debug(f"  📄 Accepted manifest saved to {self.manifest_file.name}")
+
+    def calculate_file_hash_streaming(self, file_path: Path, chunk_size: int = 8 * 1024 * 1024) -> str:
+        """SHA-256 a file without loading it into memory.
+
+        calculate_file_hash() reads the whole file, which is not viable for the
+        ~1.8GB snapshot on a CI runner.
+        """
+        hash_sha256 = hashlib.sha256()
+        with open(file_path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(chunk_size), b""):
+                hash_sha256.update(chunk)
+        return hash_sha256.hexdigest()
+
     def calculate_file_hash(self, file_path: Path) -> str:
         """Calculate SHA256 hash of file for integrity checking"""
         hash_sha256 = hashlib.sha256()
@@ -314,14 +552,46 @@ class CVEDataDownloader:
             logger.warning(f"⚠️  Could not get data stats: {e}")
             return None
     
-    def ensure_data_available(self, force_download: bool = False) -> Path:
-        """Main method to ensure CVE data is available and valid"""
+    def ensure_data_available(
+        self, force_download: bool = False, accept_baseline: bool = False
+    ) -> Path:
+        """Main method to ensure CVE data is available and valid.
+
+        Args:
+            force_download: bypass the local cache-validity check.
+            accept_baseline: skip the manifest regression check. For the rare
+                case where the producer legitimately publishes a smaller
+                snapshot (a genuine mass withdrawal) and a human has confirmed it.
+        """
         logger.info("\n🔽 Ensuring CVE data is available...")
         logger.info("=" * 50)
         
         try:
+            # Check the producer's manifest before pulling ~1.8GB. A degraded or
+            # regressed snapshot is rejected here, at zero bandwidth cost.
+            manifest = self.fetch_source_manifest()
+            if manifest is not None:
+                if accept_baseline:
+                    logger.warning(
+                        "⚠️  --accept-baseline: skipping manifest regression check"
+                    )
+                else:
+                    self.verify_manifest_healthy(manifest)
+                    self.verify_manifest_not_regressed(manifest, self.fetch_baseline_manifest())
+            else:
+                logger.warning(
+                    "⚠️  Proceeding without manifest verification "
+                    "(producer manifest unavailable)"
+                )
+
             # Download data if needed
-            data_file = self.download_data(force=force_download)
+            data_file = self.download_data(force=force_download, manifest=manifest)
+
+            # Only record the manifest once the object it describes has been
+            # downloaded and verified, so the published baseline can never name
+            # a snapshot we did not actually accept.
+            if manifest is not None:
+                self.persist_accepted_manifest(manifest)
             
             # Download CNA mapping files
             self.download_cna_mapping_files()

--- a/tests/test_refresh_fallback.py
+++ b/tests/test_refresh_fallback.py
@@ -1,0 +1,88 @@
+"""Tests for the data refresh path.
+
+A refresh that downloads nothing must never report success. Before the
+sequential fallback existed, a missing httpx made `build.py refresh --force`
+print a success message and exit 0 in about a second, having fetched nothing.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from build import CVESiteBuilder
+
+
+@pytest.fixture
+def builder(tmp_path):
+    b = CVESiteBuilder(quiet=True)
+    b.cache_dir = tmp_path
+    return b
+
+
+class TestAsyncUnavailableFallback:
+    def test_missing_httpx_falls_back_instead_of_claiming_success(self, builder):
+        """The regression this file exists for."""
+        with patch.object(CVESiteBuilder, "verify_source_manifest", return_value=None), \
+             patch("build.AsyncCVEDownloader", side_effect=ImportError("httpx is required")), \
+             patch.object(CVESiteBuilder, "refresh_data_sync", return_value=True) as fallback:
+            assert builder.refresh_data(force=True) is True
+            fallback.assert_called_once()
+            assert fallback.call_args.kwargs["force"] is True
+
+    def test_fallback_failure_is_reported(self, builder):
+        with patch.object(CVESiteBuilder, "verify_source_manifest", return_value=None), \
+             patch("build.AsyncCVEDownloader", side_effect=ImportError("httpx is required")), \
+             patch.object(CVESiteBuilder, "refresh_data_sync", return_value=False):
+            assert builder.refresh_data(force=True) is False
+
+
+class TestRefreshDataSync:
+    def _downloader(self):
+        d = MagicMock()
+        d.download_epss_data.return_value = "epss.gz"
+        d.download_kev_data.return_value = "kev.json"
+        return d
+
+    def test_downloads_every_source(self, builder):
+        d = self._downloader()
+        with patch("download_cve_data.CVEDataDownloader", return_value=d):
+            assert builder.refresh_data_sync(force=True) is True
+
+        d.download_data.assert_called_once()
+        d.download_cna_mapping_files.assert_called_once()
+        d.download_epss_data.assert_called_once_with(force=True)
+        d.parse_epss_csv.assert_called_once()
+        d.download_kev_data.assert_called_once_with(force=True)
+        d.parse_kev_json.assert_called_once()
+
+    def test_passes_manifest_through_for_verification(self, builder):
+        d = self._downloader()
+        manifest = {"cve_count": 1, "last_run_iso": "x"}
+        with patch("download_cve_data.CVEDataDownloader", return_value=d):
+            builder.refresh_data_sync(force=False, manifest=manifest)
+
+        assert d.download_data.call_args.kwargs["manifest"] == manifest
+        d.persist_accepted_manifest.assert_called_once_with(manifest)
+
+    def test_manifest_not_persisted_when_absent(self, builder):
+        d = self._downloader()
+        with patch("download_cve_data.CVEDataDownloader", return_value=d):
+            builder.refresh_data_sync(force=False, manifest=None)
+        d.persist_accepted_manifest.assert_not_called()
+
+    def test_download_failure_returns_false(self, builder):
+        """A failed download must not be reported as a successful refresh."""
+        d = self._downloader()
+        d.download_data.side_effect = OSError("Truncated download")
+        with patch("download_cve_data.CVEDataDownloader", return_value=d):
+            assert builder.refresh_data_sync(force=True) is False
+
+    def test_skips_parsing_when_supplemental_download_fails(self, builder):
+        """EPSS and KEV are non-critical, but a failed fetch must not be parsed."""
+        d = self._downloader()
+        d.download_epss_data.return_value = None
+        with patch("download_cve_data.CVEDataDownloader", return_value=d):
+            assert builder.refresh_data_sync(force=True) is True
+        d.parse_epss_csv.assert_not_called()
+        d.parse_kev_json.assert_called_once()

--- a/tests/test_regression_guards.py
+++ b/tests/test_regression_guards.py
@@ -1,0 +1,149 @@
+"""Tests for the build-side regression, freshness, and provenance guards.
+
+These are independent of the source-manifest checks in the downloader. The
+manifest catches a bad snapshot from the producer; these catch a regression in
+our own analysis code, which the producer cannot see.
+
+Keying note: everything here is publication-date bucketed, matching our own
+outputs. Manifest year_counts are CVE-ID keyed and are never compared to these.
+"""
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from build import CVESiteBuilder
+
+
+def year_data(**counts: int) -> list[dict[str, int]]:
+    """Build all_year_data-shaped input from year=count pairs."""
+    return [{"year": int(y), "total_cves": c} for y, c in counts.items()]
+
+
+def published(total: int, **counts: int) -> dict:
+    return {
+        "total_cves": total,
+        "yearly_trend": [{"year": int(y), "count": c} for y, c in counts.items()],
+    }
+
+
+@pytest.fixture
+def builder(tmp_path):
+    b = CVESiteBuilder(quiet=True)
+    b.cache_dir = tmp_path
+    b.current_year = 2026
+    b.accept_baseline = False
+    return b
+
+
+class TestVerifyNoRegression:
+    def test_accepts_growth(self, builder):
+        with patch.object(CVESiteBuilder, "fetch_published_totals",
+                          return_value=published(1000, **{"2025": 600, "2026": 400})):
+            builder.verify_no_regression(year_data(**{"2025": 600, "2026": 450}))
+
+    def test_accepts_small_decrease_within_allowance(self, builder):
+        """Genuine CVE withdrawals are a handful of records and must not fail."""
+        with patch.object(CVESiteBuilder, "fetch_published_totals",
+                          return_value=published(1000, **{"2025": 600, "2026": 400})):
+            builder.verify_no_regression(year_data(**{"2025": 595, "2026": 400}))
+
+    def test_rejects_total_regression_beyond_allowance(self, builder):
+        with patch.object(CVESiteBuilder, "fetch_published_totals",
+                          return_value=published(359880, **{"2025": 48154, "2026": 51675})):
+            with pytest.raises(RuntimeError, match="total"):
+                builder.verify_no_regression(year_data(**{"2025": 48154, "2026": 51375}))
+
+    def test_rejects_closed_year_regression(self, builder):
+        """The 2026-06-29 shape: year 2024 lost 5,254 CVEs and got them back."""
+        with patch.object(CVESiteBuilder, "fetch_published_totals",
+                          return_value=published(100000, **{"2024": 39959, "2026": 60041})):
+            with pytest.raises(RuntimeError, match="year 2024"):
+                builder.verify_no_regression(year_data(**{"2024": 34705, "2026": 70000}))
+
+    def test_rejects_vanished_closed_year(self, builder):
+        """The 2026-07-08 shape: year 1999 disappeared entirely."""
+        with patch.object(CVESiteBuilder, "fetch_published_totals",
+                          return_value=published(10000, **{"1999": 894, "2026": 9106})):
+            with pytest.raises(RuntimeError, match="year 1999"):
+                builder.verify_no_regression(year_data(**{"2026": 9106}))
+
+    def test_current_year_decrease_is_not_a_closed_year_error(self, builder):
+        """The current year is still accumulating; only the total covers it."""
+        with patch.object(CVESiteBuilder, "fetch_published_totals",
+                          return_value=published(1000, **{"2025": 600, "2026": 400})):
+            # total stays healthy, current year dips slightly
+            builder.verify_no_regression(year_data(**{"2025": 700, "2026": 395}))
+
+    def test_no_baseline_is_accepted(self, builder):
+        """First run has nothing published to compare against."""
+        with patch.object(CVESiteBuilder, "fetch_published_totals", return_value=None):
+            builder.verify_no_regression(year_data(**{"2026": 1}))
+
+    def test_accept_baseline_skips_check(self, builder):
+        builder.accept_baseline = True
+        with patch.object(CVESiteBuilder, "fetch_published_totals",
+                          side_effect=AssertionError("should not be fetched")):
+            builder.verify_no_regression(year_data(**{"2026": 1}))
+
+    def test_allowance_boundary(self, builder):
+        """Exactly at the allowance passes; one beyond fails."""
+        base = published(1000, **{"2026": 1000})
+        with patch.object(CVESiteBuilder, "fetch_published_totals", return_value=base):
+            builder.verify_no_regression(year_data(**{"2026": 990}))
+            with pytest.raises(RuntimeError):
+                builder.verify_no_regression(year_data(**{"2026": 989}))
+
+
+class TestVerifyDataFreshness:
+    def _write_cache_info(self, builder, when: datetime, **extra):
+        payload = {"download_time": when.isoformat(), **extra}
+        (builder.cache_dir / "cache_info.json").write_text(json.dumps(payload))
+        builder.source_provenance.cache_clear()
+
+    def test_accepts_fresh_data(self, builder):
+        self._write_cache_info(builder, datetime.now(UTC) - timedelta(hours=2))
+        builder.verify_data_freshness()
+
+    def test_rejects_stale_data(self, builder):
+        self._write_cache_info(builder, datetime.now(UTC) - timedelta(days=50))
+        with pytest.raises(RuntimeError, match="exceeding"):
+            builder.verify_data_freshness()
+
+    def test_missing_cache_info_warns_but_passes(self, builder):
+        """An unreadable cache info should not block a build on its own."""
+        builder.source_provenance.cache_clear()
+        builder.verify_data_freshness()
+
+
+class TestSourceProvenance:
+    def test_reports_age_and_source_fields(self, builder, tmp_path):
+        when = datetime.now(UTC) - timedelta(hours=3)
+        (tmp_path / "cache_info.json").write_text(json.dumps({
+            "download_time": when.isoformat(),
+            "source_last_run": "2026-08-18T01:07:27.380633+00:00",
+            "source_cve_count": 378426,
+        }))
+        builder.source_provenance.cache_clear()
+        p = builder.source_provenance()
+        assert p["source_cve_count"] == 378426
+        assert p["source_last_run"] == "2026-08-18T01:07:27.380633+00:00"
+        assert 2.9 < p["data_age_hours"] < 3.1
+        assert p["data_as_of"].endswith("Z")
+
+    def test_naive_timestamp_is_read_as_utc(self, builder, tmp_path):
+        """Older cache_info files predate the UTC fix."""
+        naive = (datetime.now(UTC) - timedelta(hours=1)).replace(tzinfo=None)
+        (tmp_path / "cache_info.json").write_text(json.dumps({"download_time": naive.isoformat()}))
+        builder.source_provenance.cache_clear()
+        p = builder.source_provenance()
+        assert 0.9 < p["data_age_hours"] < 1.1
+
+    def test_missing_file_returns_empty_provenance(self, builder):
+        builder.source_provenance.cache_clear()
+        p = builder.source_provenance()
+        assert p["data_as_of"] is None
+        assert p["data_age_hours"] is None

--- a/tests/test_regression_guards.py
+++ b/tests/test_regression_guards.py
@@ -32,11 +32,24 @@ def published(total: int, **counts: int) -> dict:
 
 @pytest.fixture
 def builder(tmp_path):
+    """A builder in strict mode, i.e. how it behaves in CI.
+
+    Strict is set explicitly rather than inherited from the environment so the
+    suite behaves identically whether or not CI is set in the shell running it.
+    """
     b = CVESiteBuilder(quiet=True)
     b.cache_dir = tmp_path
     b.current_year = 2026
     b.accept_baseline = False
+    b.strict_data_guards = True
     return b
+
+
+@pytest.fixture
+def lenient_builder(builder):
+    """A builder outside CI, where guards warn instead of aborting."""
+    builder.strict_data_guards = False
+    return builder
 
 
 class TestVerifyNoRegression:
@@ -110,7 +123,7 @@ class TestVerifyDataFreshness:
 
     def test_rejects_stale_data(self, builder):
         self._write_cache_info(builder, datetime.now(UTC) - timedelta(days=50))
-        with pytest.raises(RuntimeError, match="exceeding"):
+        with pytest.raises(RuntimeError, match="over the 24.0h limit"):
             builder.verify_data_freshness()
 
     def test_missing_cache_info_warns_but_passes(self, builder):
@@ -147,3 +160,32 @@ class TestSourceProvenance:
         p = builder.source_provenance()
         assert p["data_as_of"] is None
         assert p["data_age_hours"] is None
+
+
+class TestGuardEnforcementMode:
+    """The guards exist to stop bad data being published.
+
+    A local build publishes nothing, so it warns rather than blocking a
+    developer working from a deliberately old cache. CI is the deploy path.
+    """
+
+    def test_regression_warns_instead_of_raising_outside_ci(self, lenient_builder):
+        with patch.object(CVESiteBuilder, "fetch_published_totals",
+                          return_value=published(10000, **{"1999": 894, "2026": 9106})):
+            lenient_builder.verify_no_regression(year_data(**{"2026": 9106}))
+
+    def test_stale_data_warns_instead_of_raising_outside_ci(self, lenient_builder):
+        stale = datetime.now(UTC) - timedelta(days=53)
+        (lenient_builder.cache_dir / "cache_info.json").write_text(
+            json.dumps({"download_time": stale.isoformat()})
+        )
+        lenient_builder.source_provenance.cache_clear()
+        lenient_builder.verify_data_freshness()
+
+    def test_strict_mode_is_inferred_from_ci_env(self, monkeypatch):
+        monkeypatch.setenv("CI", "true")
+        assert CVESiteBuilder(quiet=True).strict_data_guards is True
+
+    def test_not_strict_without_ci_env(self, monkeypatch):
+        monkeypatch.delenv("CI", raising=False)
+        assert CVESiteBuilder(quiet=True).strict_data_guards is False

--- a/tests/test_source_manifest.py
+++ b/tests/test_source_manifest.py
@@ -1,0 +1,212 @@
+"""Tests for source manifest ingest and verification.
+
+The producer publishes metadata.json describing the snapshot behind nvd.json.
+These tests cover the gates that stand between that manifest and a build:
+health (degraded / API fallback / completeness), regression against the last
+accepted snapshot, and integrity of the downloaded object.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from data.download_cve_data import CVEDataDownloader
+from tests.fakes import FakeDataReader, FakeDataWriter, FakeHttpClient
+
+
+MANIFEST_URL = "https://nvd.handsonhacking.org/metadata.json"
+BASELINE_URL = "https://cve.icu/data/source_manifest.json"
+
+
+def make_manifest(**overrides):
+    """A healthy manifest, shaped like the real one."""
+    manifest = {
+        "last_run_iso": "2026-08-18T01:07:27.380633+00:00",
+        "cve_count": 378426,
+        "degraded": False,
+        "years_via_api": [],
+        "expected_total": 378739,
+        "completeness_ratio": 0.9992,
+        "year_counts": {"1999": 1579, "2025": 45146, "2026": 45127},
+    }
+    manifest.update(overrides)
+    return manifest
+
+
+def make_downloader(tmp_path: Path, http_client: FakeHttpClient) -> CVEDataDownloader:
+    return CVEDataDownloader(
+        cache_dir=tmp_path,
+        quiet=True,
+        http_client=http_client,
+        data_reader=FakeDataReader(),
+        data_writer=FakeDataWriter(),
+    )
+
+
+class TestFetchSourceManifest:
+    def test_returns_parsed_manifest(self, tmp_path):
+        manifest = make_manifest()
+        client = FakeHttpClient()
+        client.add_response(MANIFEST_URL, json_data=manifest)
+
+        assert make_downloader(tmp_path, client).fetch_source_manifest() == manifest
+
+    def test_returns_none_when_unavailable(self, tmp_path):
+        """An unreachable manifest must not break the build."""
+        client = FakeHttpClient()  # unregistered URLs 404
+        assert make_downloader(tmp_path, client).fetch_source_manifest() is None
+
+    def test_returns_none_on_malformed_payload(self, tmp_path):
+        client = FakeHttpClient()
+        client.add_response(MANIFEST_URL, json_data={"unexpected": True})
+        assert make_downloader(tmp_path, client).fetch_source_manifest() is None
+
+
+class TestVerifyManifestHealthy:
+    def test_accepts_healthy_manifest(self, tmp_path):
+        d = make_downloader(tmp_path, FakeHttpClient())
+        d.verify_manifest_healthy(make_manifest())  # must not raise
+
+    def test_rejects_degraded_run(self, tmp_path):
+        d = make_downloader(tmp_path, FakeHttpClient())
+        with pytest.raises(ValueError, match="degraded"):
+            d.verify_manifest_healthy(make_manifest(degraded=True))
+
+    def test_rejects_api_fallback(self, tmp_path):
+        """The REST API fallback drops records whose ID year != publication year."""
+        d = make_downloader(tmp_path, FakeHttpClient())
+        with pytest.raises(ValueError, match="REST API"):
+            d.verify_manifest_healthy(make_manifest(years_via_api=["2023"]))
+
+    def test_rejects_low_completeness(self, tmp_path):
+        """The leading-edge failure mode shows up as a completeness dip."""
+        d = make_downloader(tmp_path, FakeHttpClient())
+        with pytest.raises(ValueError, match="completeness_ratio"):
+            d.verify_manifest_healthy(make_manifest(completeness_ratio=0.97))
+
+    def test_tolerates_absent_completeness_field(self, tmp_path):
+        m = make_manifest()
+        del m["completeness_ratio"]
+        make_downloader(tmp_path, FakeHttpClient()).verify_manifest_healthy(m)
+
+
+class TestVerifyManifestNotRegressed:
+    def test_accepts_growth(self, tmp_path):
+        d = make_downloader(tmp_path, FakeHttpClient())
+        baseline = make_manifest(cve_count=378000, year_counts={"1999": 1579, "2026": 45000})
+        d.verify_manifest_not_regressed(make_manifest(), baseline)
+
+    def test_accepts_identical(self, tmp_path):
+        """A producer run with no new CVEs is normal, not a regression."""
+        d = make_downloader(tmp_path, FakeHttpClient())
+        d.verify_manifest_not_regressed(make_manifest(), make_manifest())
+
+    def test_rejects_total_regression(self, tmp_path):
+        d = make_downloader(tmp_path, FakeHttpClient())
+        baseline = make_manifest(cve_count=378426)
+        with pytest.raises(ValueError, match="total"):
+            d.verify_manifest_not_regressed(make_manifest(cve_count=377000), baseline)
+
+    def test_rejects_single_year_regression(self, tmp_path):
+        """The 2023-feed fallback showed up as one year moving, not the total."""
+        d = make_downloader(tmp_path, FakeHttpClient())
+        baseline = make_manifest()
+        regressed = make_manifest(
+            cve_count=999999,  # total grew, masking the per-year loss
+            year_counts={"1999": 1579, "2025": 40000, "2026": 45127},
+        )
+        with pytest.raises(ValueError, match="year 2025"):
+            d.verify_manifest_not_regressed(regressed, baseline)
+
+    def test_rejects_disappeared_year(self, tmp_path):
+        """Year 1999 vanishing entirely is the 2026-07-08 shape."""
+        d = make_downloader(tmp_path, FakeHttpClient())
+        with pytest.raises(ValueError, match="year 1999"):
+            d.verify_manifest_not_regressed(
+                make_manifest(year_counts={"2025": 45146, "2026": 45127}),
+                make_manifest(),
+            )
+
+    def test_no_baseline_is_accepted(self, tmp_path):
+        """First run has nothing to compare against."""
+        d = make_downloader(tmp_path, FakeHttpClient())
+        d.verify_manifest_not_regressed(make_manifest(), None)
+
+
+class TestVerifyDownloadAgainstManifest:
+    def test_accepts_matching_size(self, tmp_path):
+        d = make_downloader(tmp_path, FakeHttpClient())
+        d.verify_download_against_manifest(make_manifest(bytes=1000), 1000)
+
+    def test_rejects_size_mismatch(self, tmp_path):
+        d = make_downloader(tmp_path, FakeHttpClient())
+        with pytest.raises(OSError, match="Size mismatch"):
+            d.verify_download_against_manifest(make_manifest(bytes=1787783421), 1787000000)
+
+    def test_tolerates_absent_integrity_fields(self, tmp_path):
+        """bytes and sha256 only appear from the first post-merge producer run."""
+        d = make_downloader(tmp_path, FakeHttpClient())
+        d.verify_download_against_manifest(make_manifest(), 12345)
+
+    def test_no_manifest_skips_verification(self, tmp_path):
+        d = make_downloader(tmp_path, FakeHttpClient())
+        d.verify_download_against_manifest(None, 12345)
+
+    def test_rejects_sha256_mismatch(self, tmp_path):
+        real_cache = tmp_path / "cache"
+        real_cache.mkdir()
+        d = CVEDataDownloader(cache_dir=real_cache, quiet=True, http_client=FakeHttpClient())
+        d.cache_file.write_bytes(b"payload")
+        with pytest.raises(OSError, match="SHA-256 mismatch"):
+            d.verify_download_against_manifest(make_manifest(sha256="0" * 64), 7)
+
+    def test_accepts_correct_sha256(self, tmp_path):
+        import hashlib
+
+        real_cache = tmp_path / "cache"
+        real_cache.mkdir()
+        d = CVEDataDownloader(cache_dir=real_cache, quiet=True, http_client=FakeHttpClient())
+        payload = b"payload"
+        d.cache_file.write_bytes(payload)
+        d.verify_download_against_manifest(
+            make_manifest(sha256=hashlib.sha256(payload).hexdigest()), len(payload)
+        )
+
+
+class TestStreamingHash:
+    def test_matches_hashlib(self, tmp_path):
+        import hashlib
+
+        target = tmp_path / "blob.bin"
+        payload = b"x" * (3 * 1024 * 1024)
+        target.write_bytes(payload)
+        d = CVEDataDownloader(cache_dir=tmp_path, quiet=True, http_client=FakeHttpClient())
+        assert d.calculate_file_hash_streaming(target, chunk_size=64 * 1024) == (
+            hashlib.sha256(payload).hexdigest()
+        )
+
+
+class TestBaselineManifest:
+    def test_missing_baseline_returns_none(self, tmp_path):
+        """404 on first run is expected, not an error."""
+        client = FakeHttpClient()
+        client.add_response(BASELINE_URL, status_code=404, content=b"Not Found")
+        assert make_downloader(tmp_path, client).fetch_baseline_manifest() is None
+
+    def test_returns_baseline(self, tmp_path):
+        baseline = make_manifest(cve_count=1)
+        client = FakeHttpClient()
+        client.add_response(BASELINE_URL, json_data=baseline)
+        assert make_downloader(tmp_path, client).fetch_baseline_manifest() == baseline
+
+
+class TestPersistAcceptedManifest:
+    def test_writes_manifest(self, tmp_path):
+        writer = FakeDataWriter()
+        d = CVEDataDownloader(
+            cache_dir=tmp_path, quiet=True, http_client=FakeHttpClient(), data_writer=writer
+        )
+        manifest = make_manifest()
+        d.persist_accepted_manifest(manifest)
+        assert writer.get_json(d.manifest_file) == manifest


### PR DESCRIPTION
Consumer-side guards so the count regressions we saw between 2026-06-26 and 2026-08-17 cannot publish again. Root cause was upstream and is fixed there; this is defence in depth on our side.

## Background

Replaying the last 400 builds of `web/data/cve_all.json` found 17 builds that published a lower total than the build before them, largest −7,219. All 17 deployed and were committed to `main`. Legitimate CVE withdrawal over the same window was 21 records total, largest single instance 8, so these were faults rather than data revisions.

## What this adds

**Source manifest ingest** (`data/download_cve_data.py`). Fetches the producer's `metadata.json` before pulling the 1.79GB object, and refuses to ingest when:
- the producer reports `degraded`, or fell back to the REST API for any year (that fallback drops records whose CVE-ID year and publication year differ)
- `completeness_ratio` is below the floor
- the total or any per-year count is below the last accepted manifest
- the downloaded object does not match the manifest's `bytes` and `sha256`

The accepted manifest is republished at `/data/source_manifest.json` and read from the live site next run, so the baseline does not depend on repo state.

**Build-side guards** (`build.py`). Independent of the manifest, because the producer cannot see a bug in our own analysis code:
- `verify_no_regression` compares our per-year and total counts against what is live at cve.icu. Allowance is 10 CVEs. Sweeping the 400 historical builds: no legitimate run ever reduced the site-wide total by more than 10, and a 10-CVE allowance caught 15 of the 17 known bad builds with no false positives, where a 0.1% band caught only 7.
- `verify_data_freshness` aborts on a snapshot older than 24h.
- `source_provenance` embeds `data_as_of`, `data_age_hours`, `source_last_run` and `source_cve_count` into every output, so the site can show data age rather than build time.

Guards are fatal in CI and advisory locally, since a local build publishes nothing. `--strict` forces fatal anywhere; `--accept-baseline` skips the regression check for a confirmed real decrease.

## Two bugs found along the way

- A dropped connection produced a short file that was written and logged as a success. `content-length` is now checked against bytes received.
- `build.py refresh --force` reported success and exited 0 in about a second having downloaded nothing, whenever `httpx` was absent. Now falls back to a sequential download over the existing requests-based path, and reports failure when it fails.

## Keying note

Manifest `year_counts` are keyed by CVE-ID year; this site buckets by publication date. Year 1999 is 1,579 by ID and 923 by publication date. They are different partitions, so manifest counts are only ever compared to previous manifest counts, never to our own per-year outputs.

## Verification

- 46 new tests. Suite at 141 passing.
- Verified live that the regression guard catches all three real failure shapes: year 1999 vanishing (2026-07-08), year 2024 losing 5,254 (2026-06-29), current year losing 298 (2026-08-14).
- Verified end to end that a regressed manifest aborts *before* the download starts.
- Verified the full refresh against the producer's `schema_version: 2` manifest: 1.79GB fetched, size and SHA-256 both confirmed.

## Note on first run

Both baselines 404 on the first deploy, so it accepts whatever is published and establishes the floor. Every run after that is gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)