### PR TITLE
Let the CI gates fail, and fix what they were hiding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,16 @@ jobs:
     - name: Install linting dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ruff mypy
         pip install -r requirements.txt
         
     - name: Run Ruff linter
-      run: ruff check . --output-format=github --exit-zero
+      run: ruff check . --output-format=github
         
     - name: Run Ruff formatter check
-      run: ruff format --check . || true
+      run: ruff format --check .
         
     - name: Run mypy type checker
-      run: mypy build.py data/*.py --ignore-missing-imports --no-error-summary || true
+      run: mypy build.py data/*.py
 
   test:
     name: Tests (Python ${{ matrix.python-version }})
@@ -123,7 +122,7 @@ jobs:
         echo "✅ Build outputs verified"
         
     - name: Validate data consistency
-      run: python build.py validate --quiet || echo "Validation completed"
+      run: python build.py validate --quiet
 
   security:
     name: Security Scan
@@ -143,4 +142,4 @@ jobs:
       run: pip install pip-audit
       
     - name: Run security audit
-      run: pip-audit -r requirements.txt || true
+      run: pip-audit -r requirements.txt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,18 +29,11 @@ jobs:
         fetch-depth: 0
       
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.13'
-        
-    - name: Cache Python dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          
+        cache: 'pip'
+
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
@@ -65,6 +58,9 @@ jobs:
       run: |
         python build.py --quiet
         
+    - name: Validate build output
+      run: python build.py validate --quiet
+
     - name: Copy CNAME for GitHub Pages
       run: cp CNAME web/CNAME
       

--- a/build.py
+++ b/build.py
@@ -15,7 +15,7 @@ import tempfile
 from datetime import UTC, datetime
 from functools import cache
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
 import jinja2
 import requests
@@ -30,7 +30,7 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from data.async_downloader import AsyncCVEDownloader
-from data.logging_config import get_logger, setup_logging
+from data.logging_config import LogLevel, get_logger, setup_logging
 
 
 logger = get_logger(__name__)
@@ -44,6 +44,18 @@ app = typer.Typer(
     rich_markup_mode="rich",
     invoke_without_command=True,  # Allow running without subcommand
 )
+
+
+def _validated_log_level(value: str) -> LogLevel:
+    """Coerce a free-form --log-level string to the accepted literal set.
+
+    Typer hands us an arbitrary str, so an unrecognised value would otherwise
+    reach setup_logging and be silently accepted.
+    """
+    level = value.upper()
+    if level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        raise typer.BadParameter(f"Invalid log level {value!r}. Choose from DEBUG, INFO, WARNING, ERROR, CRITICAL.")
+    return cast("LogLevel", level)
 
 
 @app.callback(invoke_without_command=True)
@@ -179,7 +191,7 @@ class CVESiteBuilder:
         else:
             checker.verify_manifest_healthy(manifest)
             checker.verify_manifest_not_regressed(manifest, checker.fetch_baseline_manifest())
-        return manifest
+        return dict(manifest)
 
     def refresh_data(self, force: bool = False, accept_baseline: bool = False) -> bool:
         """Refresh CVE data from all sources using async parallel downloads.
@@ -597,11 +609,13 @@ class CVESiteBuilder:
 
         # Generate current year CVSS analysis
         try:
-            current_year_data = next((d for d in all_year_data if d.get("year") == self.current_year), None)
-            if current_year_data:
+            current_year_entry: dict[str, Any] | None = next(
+                (d for d in all_year_data if d.get("year") == self.current_year), None
+            )
+            if current_year_entry:
                 if not self.quiet:
                     logger.info("  📅 Generating current year CVSS analysis...")
-                current_year_cvss_analysis = cvss_analyzer.generate_current_year_cvss_analysis(current_year_data)
+                current_year_cvss_analysis = cvss_analyzer.generate_current_year_cvss_analysis(current_year_entry)
 
                 if current_year_cvss_analysis:
                     if not self.quiet:
@@ -644,11 +658,11 @@ class CVESiteBuilder:
 
         # Generate current year CWE analysis
         try:
-            current_year_data = next((d for d in all_year_data if d.get("year") == self.current_year), None)
-            if current_year_data:
+            current_year_entry = next((d for d in all_year_data if d.get("year") == self.current_year), None)
+            if current_year_entry:
                 if not self.quiet:
                     logger.info("  📅 Generating current year CWE analysis...")
-                current_year_cwe_analysis = cwe_analyzer.generate_current_year_cwe_analysis(current_year_data)
+                current_year_cwe_analysis = cwe_analyzer.generate_current_year_cwe_analysis(current_year_entry)
 
                 if current_year_cwe_analysis:
                     if not self.quiet:
@@ -1527,7 +1541,7 @@ def build(
     if quiet:
         setup_logging(level="WARNING")
     else:
-        setup_logging(level=log_level.upper())
+        setup_logging(level=_validated_log_level(log_level))
 
     builder = CVESiteBuilder(quiet=quiet)
     success = builder.build_site(

--- a/build.py
+++ b/build.py
@@ -61,9 +61,7 @@ def default_command(
         bool,
         typer.Option("--accept-baseline", help="Skip the source-manifest regression check"),
     ] = False,
-    strict: Annotated[
-        bool, typer.Option("--strict", help="Treat data guards as fatal outside CI")
-    ] = False,
+    strict: Annotated[bool, typer.Option("--strict", help="Treat data guards as fatal outside CI")] = False,
     log_level: Annotated[str, typer.Option("--log-level", help="Logging level (DEBUG, INFO, WARNING, ERROR)")] = "INFO",
 ) -> None:
     """Default command - runs build if no subcommand specified.
@@ -217,9 +215,7 @@ class CVESiteBuilder:
             if source_manifest is not None:
                 from download_cve_data import CVEDataDownloader
 
-                CVEDataDownloader(
-                    cache_dir=self.cache_dir, quiet=self.quiet
-                ).persist_accepted_manifest(source_manifest)
+                CVEDataDownloader(cache_dir=self.cache_dir, quiet=self.quiet).persist_accepted_manifest(source_manifest)
 
             # Parse supplemental data
             downloader.parse_epss()
@@ -522,9 +518,10 @@ class CVESiteBuilder:
             logger.warning("  ⚠️  Current year CNA analysis will be missing")
 
         # Fall back to NVD-based CNA analysis if CVE V5 artifacts are unavailable.
-        if not (self.data_dir / "cna_analysis.json").exists() or not (
-            self.data_dir / "cna_analysis_current_year.json"
-        ).exists():
+        if (
+            not (self.data_dir / "cna_analysis.json").exists()
+            or not (self.data_dir / "cna_analysis_current_year.json").exists()
+        ):
             self.generate_cna_analysis_fallback(all_year_data)
 
         # Generate CPE analysis
@@ -777,7 +774,7 @@ class CVESiteBuilder:
             return default
 
         try:
-            with open(file_path, "r", encoding="utf-8") as f:
+            with open(file_path, encoding="utf-8") as f:
                 return json.load(f)
         except (json.JSONDecodeError, OSError) as e:
             logger.warning(f"  ⚠️  Could not read {file_name} ({e}), using defaults for homepage summary")
@@ -1160,9 +1157,7 @@ class CVESiteBuilder:
             if strict:
                 self.strict_data_guards = True
 
-            if refresh_data and not self.refresh_data(
-                force=force_refresh, accept_baseline=accept_baseline
-            ):
+            if refresh_data and not self.refresh_data(force=force_refresh, accept_baseline=accept_baseline):
                 logger.error("❌ Data refresh failed, cannot continue build")
                 return False
 
@@ -1402,8 +1397,7 @@ class CVESiteBuilder:
 
         if age_hours > self.max_data_age_hours:
             self.enforce_data_guard(
-                f"Source snapshot is {age_hours:.1f}h old, over the "
-                f"{self.max_data_age_hours}h limit.",
+                f"Source snapshot is {age_hours:.1f}h old, over the {self.max_data_age_hours}h limit.",
                 f"  downloaded {info.get('data_as_of')}",
                 "Stale data must not be published under a fresh timestamp. "
                 "Refresh with 'python build.py refresh --force'.",
@@ -1443,9 +1437,7 @@ class CVESiteBuilder:
                 if stamp.tzinfo is None:
                     stamp = stamp.replace(tzinfo=UTC)
                 provenance["data_as_of"] = stamp.isoformat().replace("+00:00", "Z")
-                provenance["data_age_hours"] = round(
-                    (datetime.now(UTC) - stamp).total_seconds() / 3600, 1
-                )
+                provenance["data_age_hours"] = round((datetime.now(UTC) - stamp).total_seconds() / 3600, 1)
             except ValueError as e:
                 logger.warning(f"  ⚠️  Could not parse download_time {download_time!r}: {e}")
 
@@ -1462,9 +1454,7 @@ class CVESiteBuilder:
         """
         counts = {int(d["year"]): d.get("total_cves", 0) for d in all_year_data if "year" in d}
         earliest_year = self.available_years[0]
-        empty_years = [
-            year for year in range(earliest_year, self.current_year) if counts.get(year, 0) <= 0
-        ]
+        empty_years = [year for year in range(earliest_year, self.current_year) if counts.get(year, 0) <= 0]
         if empty_years:
             raise RuntimeError(
                 f"Historical year(s) with zero CVEs detected: {', '.join(map(str, empty_years))}. "
@@ -1472,8 +1462,7 @@ class CVESiteBuilder:
                 "downloaded. Aborting build to avoid publishing or committing partial data."
             )
         logger.info(
-            f"    ✅ Historical year coverage verified ({earliest_year}-{self.current_year - 1}, "
-            "all years non-empty)"
+            f"    ✅ Historical year coverage verified ({earliest_year}-{self.current_year - 1}, all years non-empty)"
         )
 
 
@@ -1511,8 +1500,7 @@ def build(
         bool,
         typer.Option(
             "--strict",
-            help="Treat data freshness and regression guards as fatal outside CI "
-            "(they are always fatal in CI).",
+            help="Treat data freshness and regression guards as fatal outside CI (they are always fatal in CI).",
         ),
     ] = False,
     log_level: Annotated[str, typer.Option("--log-level", help="Logging level")] = "INFO",

--- a/data/async_downloader.py
+++ b/data/async_downloader.py
@@ -38,8 +38,8 @@ except ImportError:
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 
@@ -279,7 +279,7 @@ class AsyncCVEDownloader:
         results_dict: dict[str, DownloadResult] = {}
 
         for name, result in zip(source_names, results):
-            if isinstance(result, Exception):
+            if isinstance(result, BaseException):
                 results_dict[name] = DownloadResult(
                     source=name,
                     success=False,
@@ -429,9 +429,11 @@ async def main_async() -> None:
 
     args = parser.parse_args()
 
-    cache_dir = Path(args.cache_dir) if args.cache_dir else None
+    # cache_dir is typed Path and passed through Path() in __post_init__, so
+    # None would fail there. Fall back to the dataclass default instead.
+    downloader = AsyncCVEDownloader(cache_dir=Path(args.cache_dir)) if args.cache_dir else AsyncCVEDownloader()
 
-    async with AsyncCVEDownloader(cache_dir=cache_dir) as downloader:
+    async with downloader:
         results = await downloader.download_all_sources(force=args.force)
 
         # Parse supplemental data

--- a/data/async_downloader.py
+++ b/data/async_downloader.py
@@ -10,11 +10,12 @@ Usage:
     # Async context manager for parallel downloads
     async with AsyncCVEDownloader() as downloader:
         results = await downloader.download_all_sources()
-    
+
     # Or use the sync wrapper
     downloader = AsyncCVEDownloader()
     results = downloader.download_all_sync()
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -27,8 +28,10 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+
 try:
     import httpx
+
     HTTPX_AVAILABLE = True
 except ImportError:
     HTTPX_AVAILABLE = False
@@ -44,6 +47,7 @@ logger = get_logger(__name__)
 @dataclass
 class DownloadResult:
     """Result of a single download operation."""
+
     source: str
     success: bool
     path: Path | None = None
@@ -56,39 +60,40 @@ class DownloadResult:
 @dataclass
 class AsyncCVEDownloader:
     """Async downloader for CVE data from multiple sources.
-    
+
     Downloads data from 5 sources in parallel:
     1. NVD CVE database (nvd.json) - Main CVE data
     2. CNA List (cna_list.json) - CNA organization list
-    3. CNA Name Map (cna_name_map.json) - CNA name mappings  
+    3. CNA Name Map (cna_name_map.json) - CNA name mappings
     4. EPSS Scores (epss_scores-current.csv.gz) - Exploit prediction scores
     5. KEV Catalog (known_exploited_vulnerabilities.json) - Known exploited CVEs
-    
+
     Attributes:
         cache_dir: Directory for cached downloads
         cache_duration: How long to consider cache valid
         timeout: HTTP request timeout in seconds
         quiet: Suppress info logging
     """
-    cache_dir: Path = field(default_factory=lambda: Path(__file__).parent / 'cache')
+
+    cache_dir: Path = field(default_factory=lambda: Path(__file__).parent / "cache")
     cache_duration: timedelta = field(default_factory=lambda: timedelta(hours=4))
     timeout: int = 120
     quiet: bool = False
-    
+
     # URL configurations
     nvd_url: str = "https://nvd.handsonhacking.org/nvd.json"
     cna_list_url: str = "https://raw.githubusercontent.com/CVEProject/cve-website/dev/src/assets/data/CNAsList.json"
     cna_name_map_url: str = "https://www.cve.org/cve-partner-name-map.json"
     epss_url: str = "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz"
     kev_url: str = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
-    
+
     _client: Any = field(default=None, init=False, repr=False)
-    
+
     def __post_init__(self) -> None:
         """Ensure cache directory exists."""
         self.cache_dir = Path(self.cache_dir)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Define cache file paths
         self.nvd_file = self.cache_dir / "nvd.json"
         self.cna_list_file = self.cache_dir / "cna_list.json"
@@ -98,20 +103,20 @@ class AsyncCVEDownloader:
         self.kev_cache_file = self.cache_dir / "known_exploited_vulnerabilities.json"
         self.kev_parsed_file = self.cache_dir / "known_exploited_vulnerabilities_parsed.json"
         self.cache_info_file = self.cache_dir / "cache_info.json"
-    
-    async def __aenter__(self) -> "AsyncCVEDownloader":
+
+    async def __aenter__(self) -> AsyncCVEDownloader:
         """Create async HTTP client on context entry."""
         if not HTTPX_AVAILABLE:
             raise ImportError("httpx is required for async downloads. Install with: pip install httpx")
         self._client = httpx.AsyncClient(timeout=self.timeout, follow_redirects=True)
         return self
-    
+
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Close async HTTP client on context exit."""
         if self._client:
             await self._client.aclose()
             self._client = None
-    
+
     def _is_cache_valid(self, cache_file: Path) -> bool:
         """Check if a cache file exists and is not expired."""
         if not cache_file.exists():
@@ -121,7 +126,7 @@ class AsyncCVEDownloader:
             return datetime.now() - mtime < self.cache_duration
         except OSError:
             return False
-    
+
     async def _download_file(
         self,
         url: str,
@@ -131,19 +136,19 @@ class AsyncCVEDownloader:
         is_binary: bool = False,
     ) -> DownloadResult:
         """Download a single file with caching support.
-        
+
         Args:
             url: URL to download from
             cache_file: Path to save the file
             source_name: Human-readable name for logging
             force: Force download even if cache is valid
             is_binary: Whether to save as binary (for gzip files)
-            
+
         Returns:
             DownloadResult with success status and metadata
         """
         start_time = datetime.now()
-        
+
         # Check cache first
         if not force and self._is_cache_valid(cache_file):
             if not self.quiet:
@@ -156,27 +161,27 @@ class AsyncCVEDownloader:
                 duration_seconds=0.0,
                 from_cache=True,
             )
-        
+
         if not self.quiet:
             logger.info(f"  🔽 Downloading {source_name}...")
-        
+
         try:
             response = await self._client.get(url)
             response.raise_for_status()
-            
+
             # Save content
             if is_binary:
                 cache_file.write_bytes(response.content)
             else:
-                cache_file.write_text(response.text, encoding='utf-8')
-            
+                cache_file.write_text(response.text, encoding="utf-8")
+
             duration = (datetime.now() - start_time).total_seconds()
             size = len(response.content)
-            
+
             if not self.quiet:
-                size_str = f"{size / (1024*1024):.2f} MB" if size > 1024*1024 else f"{size / 1024:.1f} KB"
+                size_str = f"{size / (1024 * 1024):.2f} MB" if size > 1024 * 1024 else f"{size / 1024:.1f} KB"
                 logger.info(f"  ✅ {source_name} complete ({size_str} in {duration:.1f}s)")
-            
+
             return DownloadResult(
                 source=source_name,
                 success=True,
@@ -184,11 +189,11 @@ class AsyncCVEDownloader:
                 size_bytes=size,
                 duration_seconds=duration,
             )
-            
+
         except httpx.HTTPError as e:
             duration = (datetime.now() - start_time).total_seconds()
             error_msg = str(e)
-            
+
             # Try to use stale cache as fallback
             if cache_file.exists():
                 logger.warning(f"  ⚠️  {source_name} download failed, using stale cache: {error_msg}")
@@ -201,7 +206,7 @@ class AsyncCVEDownloader:
                     from_cache=True,
                     error=f"Using stale cache: {error_msg}",
                 )
-            
+
             logger.error(f"  ❌ {source_name} download failed: {error_msg}")
             return DownloadResult(
                 source=source_name,
@@ -209,66 +214,56 @@ class AsyncCVEDownloader:
                 duration_seconds=duration,
                 error=error_msg,
             )
-    
+
     async def download_nvd(self, force: bool = False) -> DownloadResult:
         """Download NVD CVE database."""
-        result = await self._download_file(
-            self.nvd_url, self.nvd_file, "NVD CVE Data", force
-        )
-        
+        result = await self._download_file(self.nvd_url, self.nvd_file, "NVD CVE Data", force)
+
         # Update cache info if successful
         if result.success and not result.from_cache:
             cache_info = {
-                'download_time': datetime.now().isoformat(),
-                'file_size': result.size_bytes,
-                'file_hash': self._calculate_hash(self.nvd_file),
-                'source_url': self.nvd_url,
+                "download_time": datetime.now().isoformat(),
+                "file_size": result.size_bytes,
+                "file_hash": self._calculate_hash(self.nvd_file),
+                "source_url": self.nvd_url,
             }
             self.cache_info_file.write_text(json.dumps(cache_info, indent=2))
-        
+
         return result
-    
+
     async def download_cna_list(self, force: bool = False) -> DownloadResult:
         """Download CNA organization list."""
-        return await self._download_file(
-            self.cna_list_url, self.cna_list_file, "CNA List", force
-        )
-    
+        return await self._download_file(self.cna_list_url, self.cna_list_file, "CNA List", force)
+
     async def download_cna_name_map(self, force: bool = False) -> DownloadResult:
         """Download CNA name mapping."""
-        return await self._download_file(
-            self.cna_name_map_url, self.cna_name_map_file, "CNA Name Map", force
-        )
-    
+        return await self._download_file(self.cna_name_map_url, self.cna_name_map_file, "CNA Name Map", force)
+
     async def download_epss(self, force: bool = False) -> DownloadResult:
         """Download EPSS scores (gzipped CSV)."""
-        return await self._download_file(
-            self.epss_url, self.epss_cache_file, "EPSS Scores", force, is_binary=True
-        )
-    
+        return await self._download_file(self.epss_url, self.epss_cache_file, "EPSS Scores", force, is_binary=True)
+
     async def download_kev(self, force: bool = False) -> DownloadResult:
         """Download CISA KEV catalog."""
-        return await self._download_file(
-            self.kev_url, self.kev_cache_file, "KEV Catalog", force
-        )
-    
+        return await self._download_file(self.kev_url, self.kev_cache_file, "KEV Catalog", force)
+
     async def download_all_sources(self, force: bool = False) -> dict[str, DownloadResult]:
         """Download all data sources in parallel.
-        
+
         This is the main method that provides ~3x speedup by running
         all downloads concurrently.
-        
+
         Args:
             force: Force download even if caches are valid
-            
+
         Returns:
             Dict mapping source names to DownloadResult objects
         """
         if not self.quiet:
             logger.info("🚀 Starting parallel download of all CVE data sources...")
-        
+
         start_time = datetime.now()
-        
+
         # Run all downloads in parallel
         results = await asyncio.gather(
             self.download_nvd(force),
@@ -278,11 +273,11 @@ class AsyncCVEDownloader:
             self.download_kev(force),
             return_exceptions=True,
         )
-        
+
         # Convert to dict and handle exceptions
-        source_names = ['nvd', 'cna_list', 'cna_name_map', 'epss', 'kev']
+        source_names = ["nvd", "cna_list", "cna_name_map", "epss", "kev"]
         results_dict: dict[str, DownloadResult] = {}
-        
+
         for name, result in zip(source_names, results):
             if isinstance(result, Exception):
                 results_dict[name] = DownloadResult(
@@ -292,33 +287,33 @@ class AsyncCVEDownloader:
                 )
             else:
                 results_dict[name] = result
-        
+
         total_duration = (datetime.now() - start_time).total_seconds()
-        
+
         # Summary logging
         if not self.quiet:
             successful = sum(1 for r in results_dict.values() if r.success)
             total_bytes = sum(r.size_bytes for r in results_dict.values() if r.success)
             cached = sum(1 for r in results_dict.values() if r.from_cache)
-            
-            logger.info(f"\n📊 Download Summary:")
+
+            logger.info("\n📊 Download Summary:")
             logger.info(f"  ✅ Successful: {successful}/{len(results_dict)}")
-            logger.info(f"  📦 Total size: {total_bytes / (1024*1024):.2f} MB")
+            logger.info(f"  📦 Total size: {total_bytes / (1024 * 1024):.2f} MB")
             logger.info(f"  💾 From cache: {cached}")
             logger.info(f"  ⏱️  Total time: {total_duration:.1f}s")
-        
+
         return results_dict
-    
+
     def _calculate_hash(self, file_path: Path) -> str:
         """Calculate SHA256 hash of file."""
         hash_sha256 = hashlib.sha256()
         content = file_path.read_bytes()
         hash_sha256.update(content)
         return hash_sha256.hexdigest()
-    
+
     def parse_epss(self) -> dict[str, dict[str, float]] | None:
         """Parse EPSS CSV into JSON mapping.
-        
+
         Returns dict like:
         {
             "CVE-2024-12345": {"epss_score": 0.1234, "epss_percentile": 0.9876},
@@ -327,14 +322,14 @@ class AsyncCVEDownloader:
         """
         if not self.epss_cache_file.exists():
             return None
-        
+
         if not self.quiet:
             logger.info("  🔍 Parsing EPSS CSV...")
-        
+
         mapping: dict[str, dict[str, float]] = {}
         try:
             with gzip.open(self.epss_cache_file, mode="rt", encoding="utf-8") as f:
-                lines = (line for line in f if not line.startswith('#'))
+                lines = (line for line in f if not line.startswith("#"))
                 reader = csv.DictReader(lines)
                 for row in reader:
                     cve_id = row.get("cve") or row.get("CVE")
@@ -352,22 +347,22 @@ class AsyncCVEDownloader:
                         "epss_score": score,
                         "epss_percentile": percentile,
                     }
-            
+
             # Save parsed JSON
-            self.epss_parsed_file.write_text(json.dumps(mapping), encoding='utf-8')
-            
+            self.epss_parsed_file.write_text(json.dumps(mapping), encoding="utf-8")
+
             if not self.quiet:
                 logger.info(f"  ✅ EPSS parsed: {len(mapping):,} CVEs")
-            
+
             return mapping
-            
+
         except (gzip.BadGzipFile, csv.Error, OSError) as e:
             logger.warning(f"  ⚠️  EPSS parse failed: {e}")
             return None
-    
+
     def parse_kev(self) -> dict[str, bool] | None:
         """Parse KEV JSON into CVE set.
-        
+
         Returns dict like:
         {
             "CVE-2024-12345": True,
@@ -376,17 +371,17 @@ class AsyncCVEDownloader:
         """
         if not self.kev_cache_file.exists():
             return None
-        
+
         if not self.quiet:
             logger.info("  🔍 Parsing KEV JSON...")
-        
+
         try:
-            raw = json.loads(self.kev_cache_file.read_text(encoding='utf-8'))
-            
+            raw = json.loads(self.kev_cache_file.read_text(encoding="utf-8"))
+
             vulnerabilities = raw.get("vulnerabilities")
             if vulnerabilities is None and isinstance(raw, list):
                 vulnerabilities = raw
-            
+
             mapping: dict[str, bool] = {
                 cve_id.strip(): True
                 for entry in (vulnerabilities if isinstance(vulnerabilities, list) else [])
@@ -394,54 +389,55 @@ class AsyncCVEDownloader:
                 and isinstance(cve_id, str)
                 and cve_id.startswith("CVE-")
             }
-            
+
             # Save parsed JSON
-            self.kev_parsed_file.write_text(json.dumps(mapping), encoding='utf-8')
-            
+            self.kev_parsed_file.write_text(json.dumps(mapping), encoding="utf-8")
+
             if not self.quiet:
                 logger.info(f"  ✅ KEV parsed: {len(mapping):,} CVEs")
-            
+
             return mapping
-            
+
         except (json.JSONDecodeError, OSError) as e:
             logger.warning(f"  ⚠️  KEV parse failed: {e}")
             return None
-    
+
     def download_all_sync(self, force: bool = False) -> dict[str, DownloadResult]:
         """Synchronous wrapper for download_all_sources().
-        
+
         Use this when you need to call from non-async code.
-        
+
         Example:
             downloader = AsyncCVEDownloader()
             results = downloader.download_all_sync()
         """
+
         async def _run() -> dict[str, DownloadResult]:
             async with self as dl:
                 return await dl.download_all_sources(force)
-        
+
         return asyncio.run(_run())
 
 
 async def main_async() -> None:
     """Async main entry point."""
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Download CVE data (async)")
-    parser.add_argument('--force', action='store_true', help='Force download')
-    parser.add_argument('--cache-dir', help='Custom cache directory')
-    
+    parser.add_argument("--force", action="store_true", help="Force download")
+    parser.add_argument("--cache-dir", help="Custom cache directory")
+
     args = parser.parse_args()
-    
+
     cache_dir = Path(args.cache_dir) if args.cache_dir else None
-    
+
     async with AsyncCVEDownloader(cache_dir=cache_dir) as downloader:
         results = await downloader.download_all_sources(force=args.force)
-        
+
         # Parse supplemental data
         downloader.parse_epss()
         downloader.parse_kev()
-        
+
         # Show results
         for name, result in results.items():
             status = "✅" if result.success else "❌"
@@ -453,5 +449,5 @@ def main() -> None:
     asyncio.run(main_async())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/data/calendar_analysis.py
+++ b/data/calendar_analysis.py
@@ -3,6 +3,7 @@
 Calendar Analysis Module for CVE.ICU
 Generates daily CVE publication data for calendar heatmap visualization
 """
+
 from __future__ import annotations
 
 import json
@@ -13,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+
 
 try:
     from data.logging_config import get_logger
@@ -25,297 +27,289 @@ logger = get_logger(__name__)
 @dataclass
 class CalendarAnalyzer:
     """Analyzer for generating calendar-based CVE publication data"""
+
     base_dir: Path
     cache_dir: Path
     data_dir: Path
     quiet: bool = False
-    
+
     def __post_init__(self) -> None:
         """Convert path arguments to Path objects and set up derived attributes."""
         self.base_dir = Path(self.base_dir)
         self.cache_dir = Path(self.cache_dir)
         self.data_dir = Path(self.data_dir)
-        self.nvd_file: Path = self.cache_dir / 'nvd.json'
-        
+        self.nvd_file: Path = self.cache_dir / "nvd.json"
+
     def load_nvd_data(self) -> list[dict[str, Any]]:
         """Load and parse NVD data from JSONL file"""
         if not self.quiet:
             logger.info("    📂 Loading NVD data for calendar analysis...")
-        
+
         if not self.nvd_file.exists():
             logger.error(f"    ❌ NVD file not found: {self.nvd_file}")
             return []
-        
+
         cve_records = []
         try:
-            with open(self.nvd_file, 'r', encoding='utf-8') as f:
+            with open(self.nvd_file, encoding="utf-8") as f:
                 data = json.load(f)
-                
+
             if not self.quiet:
                 logger.info(f"    📊 Processing {len(data):,} CVE records for calendar analysis...")
-            
+
             for entry in data:
                 try:
-                    cve_id = entry.get('cve', {}).get('id', '')
-                    published = entry.get('cve', {}).get('published', '')
-                    
+                    cve_id = entry.get("cve", {}).get("id", "")
+                    published = entry.get("cve", {}).get("published", "")
+
                     # Extract CVSS score (try v3.1 first, then v3.0, then v2.0)
                     cvss_score = None
-                    metrics = entry.get('cve', {}).get('metrics', {})
-                    
-                    if 'cvssMetricV31' in metrics and metrics['cvssMetricV31']:
-                        cvss_score = metrics['cvssMetricV31'][0].get('cvssData', {}).get('baseScore')
-                    elif 'cvssMetricV30' in metrics and metrics['cvssMetricV30']:
-                        cvss_score = metrics['cvssMetricV30'][0].get('cvssData', {}).get('baseScore')
-                    elif 'cvssMetricV2' in metrics and metrics['cvssMetricV2']:
-                        cvss_score = metrics['cvssMetricV2'][0].get('cvssData', {}).get('baseScore')
-                    
+                    metrics = entry.get("cve", {}).get("metrics", {})
+
+                    if "cvssMetricV31" in metrics and metrics["cvssMetricV31"]:
+                        cvss_score = metrics["cvssMetricV31"][0].get("cvssData", {}).get("baseScore")
+                    elif "cvssMetricV30" in metrics and metrics["cvssMetricV30"]:
+                        cvss_score = metrics["cvssMetricV30"][0].get("cvssData", {}).get("baseScore")
+                    elif "cvssMetricV2" in metrics and metrics["cvssMetricV2"]:
+                        cvss_score = metrics["cvssMetricV2"][0].get("cvssData", {}).get("baseScore")
+
                     # Skip rejected CVEs
-                    status = entry.get('cve', {}).get('vulnStatus', '')
-                    if 'Rejected' in status:
+                    status = entry.get("cve", {}).get("vulnStatus", "")
+                    if "Rejected" in status:
                         continue
-                    
+
                     if cve_id and published:
-                        cve_records.append({
-                            'cve_id': cve_id,
-                            'published': published,
-                            'cvss_score': cvss_score
-                        })
-                        
+                        cve_records.append({"cve_id": cve_id, "published": published, "cvss_score": cvss_score})
+
                 except (KeyError, TypeError, ValueError):
                     continue  # Skip malformed entries
-                    
+
             if not self.quiet:
                 logger.info(f"    ✅ Loaded {len(cve_records):,} valid CVE records")
             return cve_records
-            
+
         except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
             logger.error(f"    ❌ Error loading NVD data: {e}")
             return []
-    
+
     def process_daily_data(self, cve_records: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
         """Process CVE records into daily publication counts"""
         if not self.quiet:
             logger.info("    📅 Processing daily CVE publication data...")
-        
+
         daily_counts: dict[str, int] = defaultdict(int)
         daily_scores: dict[str, list[float]] = defaultdict(list)
-        
+
         for record in cve_records:
             try:
                 # Parse publication date
-                pub_date = datetime.fromisoformat(record['published'].replace('Z', '+00:00'))
-                date_key = pub_date.strftime('%Y-%m-%d')
-                
+                pub_date = datetime.fromisoformat(record["published"].replace("Z", "+00:00"))
+                date_key = pub_date.strftime("%Y-%m-%d")
+
                 daily_counts[date_key] += 1
-                
-                if record['cvss_score'] is not None:
-                    daily_scores[date_key].append(record['cvss_score'])
-                    
+
+                if record["cvss_score"] is not None:
+                    daily_scores[date_key].append(record["cvss_score"])
+
             except (ValueError, KeyError, TypeError):
                 continue  # Skip invalid dates
-        
+
         # Calculate daily averages
         daily_data = {}
         for date_key, count in daily_counts.items():
             scores = daily_scores.get(date_key, [])
 
             entry: dict[str, Any] = {
-                'date': date_key,
-                'count': count,
+                "date": date_key,
+                "count": count,
             }
             # Only include CVSS fields when there is actual score data
             if scores:
-                entry['avg_cvss_score'] = round(float(np.mean(scores)), 1)
-                entry['cvss_count'] = len(scores)
+                entry["avg_cvss_score"] = round(float(np.mean(scores)), 1)
+                entry["cvss_count"] = len(scores)
 
             daily_data[date_key] = entry
-        
+
         if not self.quiet:
             logger.info(f"    ✅ Processed {len(daily_data):,} days of CVE data")
         return daily_data
-    
-    def calculate_statistics(self, daily_data: dict[str, dict[str, Any]], cve_records: list[dict[str, Any]]) -> dict[str, Any]:
+
+    def calculate_statistics(
+        self, daily_data: dict[str, dict[str, Any]], cve_records: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         """Calculate overall statistics for the calendar analysis"""
         if not self.quiet:
             logger.info("    📊 Calculating calendar statistics...")
-        
+
         total_cves = len(cve_records)
         total_days = len(daily_data)
-        
+
         # Calculate date range
-        dates = [datetime.strptime(date_key, '%Y-%m-%d') for date_key in daily_data.keys()]
+        dates = [datetime.strptime(date_key, "%Y-%m-%d") for date_key in daily_data]
         start_date = min(dates) if dates else datetime.now()
         end_date = max(dates) if dates else datetime.now()
-        
+
         # Calculate averages
-        daily_counts = [data['count'] for data in daily_data.values()]
+        daily_counts = [data["count"] for data in daily_data.values()]
         avg_per_day = np.mean(daily_counts) if daily_counts else 0
         max_per_day = max(daily_counts) if daily_counts else 0
         min_per_day = min(daily_counts) if daily_counts else 0
-        
+
         # Find peak day
-        peak_day_data = max(daily_data.values(), key=lambda x: x['count']) if daily_data else None
-        
+        peak_day_data = max(daily_data.values(), key=lambda x: x["count"]) if daily_data else None
+
         # Calculate CVSS statistics
-        cvss_scores = [record['cvss_score'] for record in cve_records if record['cvss_score'] is not None]
+        cvss_scores = [record["cvss_score"] for record in cve_records if record["cvss_score"] is not None]
         avg_cvss = np.mean(cvss_scores) if cvss_scores else None
-        
+
         # Calculate current year statistics
         current_year = datetime.now().year
         current_year_data = {k: v for k, v in daily_data.items() if k.startswith(str(current_year))}
-        current_year_cves = sum(data['count'] for data in current_year_data.values())
-        
+        current_year_cves = sum(data["count"] for data in current_year_data.values())
+
         statistics = {
-            'total_cves': total_cves,
-            'total_days_with_data': total_days,
-            'date_range': {
-                'start': start_date.strftime('%Y-%m-%d'),
-                'end': end_date.strftime('%Y-%m-%d')
+            "total_cves": total_cves,
+            "total_days_with_data": total_days,
+            "date_range": {"start": start_date.strftime("%Y-%m-%d"), "end": end_date.strftime("%Y-%m-%d")},
+            "daily_stats": {
+                "average_per_day": round(avg_per_day, 2),
+                "max_per_day": max_per_day,
+                "min_per_day": min_per_day,
+                "peak_day": {
+                    "date": peak_day_data["date"] if peak_day_data else None,
+                    "count": peak_day_data["count"] if peak_day_data else 0,
+                },
             },
-            'daily_stats': {
-                'average_per_day': round(avg_per_day, 2),
-                'max_per_day': max_per_day,
-                'min_per_day': min_per_day,
-                'peak_day': {
-                    'date': peak_day_data['date'] if peak_day_data else None,
-                    'count': peak_day_data['count'] if peak_day_data else 0
-                }
+            "cvss_stats": {
+                "average_score": round(avg_cvss, 2) if avg_cvss else None,
+                "total_with_scores": len(cvss_scores),
             },
-            'cvss_stats': {
-                'average_score': round(avg_cvss, 2) if avg_cvss else None,
-                'total_with_scores': len(cvss_scores)
+            "current_year": {
+                "year": current_year,
+                "total_cves": current_year_cves,
+                "days_with_data": len(current_year_data),
             },
-            'current_year': {
-                'year': current_year,
-                'total_cves': current_year_cves,
-                'days_with_data': len(current_year_data)
-            }
         }
-        
+
         return statistics
-    
+
     def generate_calendar_analysis(self) -> dict[str, Any] | None:
         """Generate comprehensive calendar analysis"""
         logger.info("  📅 Generating calendar analysis...")
-        
+
         # Load CVE data
         cve_records = self.load_nvd_data()
         if not cve_records:
             logger.error("  ❌ No CVE data available for calendar analysis")
             return None
-        
+
         # Process daily data
         daily_data = self.process_daily_data(cve_records)
         if not daily_data:
             logger.error("  ❌ No daily data generated")
             return None
-        
+
         # Calculate statistics
         statistics = self.calculate_statistics(daily_data, cve_records)
-        
+
         # Prepare calendar data for frontend
         calendar_data = []
         for date_key, data in daily_data.items():
             entry: dict[str, Any] = {
-                'date': date_key,
-                'value': data['count'],
+                "date": date_key,
+                "value": data["count"],
             }
             # Only include CVSS fields when score data exists (saves ~bytes per entry)
-            if 'avg_cvss_score' in data:
-                entry['avg_cvss'] = data['avg_cvss_score']
-                entry['cvss_count'] = data['cvss_count']
+            if "avg_cvss_score" in data:
+                entry["avg_cvss"] = data["avg_cvss_score"]
+                entry["cvss_count"] = data["cvss_count"]
             calendar_data.append(entry)
-        
+
         # Sort by date
-        calendar_data.sort(key=lambda x: x['date'])
-        
+        calendar_data.sort(key=lambda x: x["date"])
+
         analysis_result = {
-            'generated_at': datetime.now().isoformat(),
-            'statistics': statistics,
-            'daily_data': calendar_data,
-            'metadata': {
-                'total_records': len(cve_records),
-                'total_days': len(daily_data),
-                'data_source': 'NVD JSONL',
-                'analysis_type': 'calendar_heatmap'
-            }
+            "generated_at": datetime.now().isoformat(),
+            "statistics": statistics,
+            "daily_data": calendar_data,
+            "metadata": {
+                "total_records": len(cve_records),
+                "total_days": len(daily_data),
+                "data_source": "NVD JSONL",
+                "analysis_type": "calendar_heatmap",
+            },
         }
-        
+
         # Save to file
-        output_file = self.data_dir / 'calendar_analysis.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "calendar_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(analysis_result, f, indent=2)
-        
+
         if not self.quiet:
             logger.info(f"  ✅ Generated calendar analysis with {len(calendar_data):,} days of data")
         return analysis_result
-    
+
     def generate_current_year_calendar_analysis(self) -> dict[str, Any] | None:
         """Generate current year specific calendar analysis"""
         logger.info("  📅 Generating current year calendar analysis...")
-        
+
         # Load full analysis first
         full_analysis = self.generate_calendar_analysis()
         if not full_analysis:
             return None
-        
+
         current_year = datetime.now().year
-        
+
         # Filter for current year data
         current_year_daily = [
-            data for data in full_analysis['daily_data'] 
-            if data['date'].startswith(str(current_year))
+            data for data in full_analysis["daily_data"] if data["date"].startswith(str(current_year))
         ]
-        
+
         # Calculate current year statistics
         if current_year_daily:
-            total_cves = sum(data['value'] for data in current_year_daily)
+            total_cves = sum(data["value"] for data in current_year_daily)
             avg_per_day = total_cves / len(current_year_daily) if current_year_daily else 0
-            max_day = max(current_year_daily, key=lambda x: x['value']) if current_year_daily else None
-            
+            max_day = max(current_year_daily, key=lambda x: x["value"]) if current_year_daily else None
+
             # Calculate CVSS average for current year
-            cvss_scores = [data['avg_cvss'] for data in current_year_daily if data.get('avg_cvss') is not None]
+            cvss_scores = [data["avg_cvss"] for data in current_year_daily if data.get("avg_cvss") is not None]
             avg_cvss = np.mean(cvss_scores) if cvss_scores else None
-            
+
             current_year_stats = {
-                'year': current_year,
-                'total_cves': total_cves,
-                'total_days_with_data': len(current_year_daily),
-                'average_per_day': round(avg_per_day, 2),
-                'peak_day': {
-                    'date': max_day['date'] if max_day else None,
-                    'count': max_day['value'] if max_day else 0
-                },
-                'average_cvss': round(avg_cvss, 2) if avg_cvss else None
+                "year": current_year,
+                "total_cves": total_cves,
+                "total_days_with_data": len(current_year_daily),
+                "average_per_day": round(avg_per_day, 2),
+                "peak_day": {"date": max_day["date"] if max_day else None, "count": max_day["value"] if max_day else 0},
+                "average_cvss": round(avg_cvss, 2) if avg_cvss else None,
             }
         else:
             current_year_stats = {
-                'year': current_year,
-                'total_cves': 0,
-                'total_days_with_data': 0,
-                'average_per_day': 0,
-                'peak_day': {'date': None, 'count': 0},
-                'average_cvss': None
+                "year": current_year,
+                "total_cves": 0,
+                "total_days_with_data": 0,
+                "average_per_day": 0,
+                "peak_day": {"date": None, "count": 0},
+                "average_cvss": None,
             }
-        
+
         current_year_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'statistics': current_year_stats,
-            'daily_data': current_year_daily,
-            'metadata': {
-                'year': current_year,
-                'total_days': len(current_year_daily),
-                'data_source': 'NVD JSONL',
-                'analysis_type': 'current_year_calendar'
-            }
+            "generated_at": datetime.now().isoformat(),
+            "statistics": current_year_stats,
+            "daily_data": current_year_daily,
+            "metadata": {
+                "year": current_year,
+                "total_days": len(current_year_daily),
+                "data_source": "NVD JSONL",
+                "analysis_type": "current_year_calendar",
+            },
         }
-        
+
         # Save to file
-        output_file = self.data_dir / 'calendar_analysis_current_year.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "calendar_analysis_current_year.json"
+        with open(output_file, "w") as f:
             json.dump(current_year_analysis, f, indent=2)
-        
+
         if not self.quiet:
             logger.info(f"  ✅ Generated current year calendar analysis with {len(current_year_daily):,} days")
         return current_year_analysis
@@ -324,15 +318,15 @@ class CalendarAnalyzer:
 if __name__ == "__main__":
     # Test the analyzer
     base_dir = Path(__file__).parent.parent
-    cache_dir = base_dir / 'data' / 'cache'
-    data_dir = base_dir / 'web' / 'data'
-    
+    cache_dir = base_dir / "data" / "cache"
+    data_dir = base_dir / "web" / "data"
+
     analyzer = CalendarAnalyzer(base_dir, cache_dir, data_dir)
-    
+
     logger.info("🗓️  Testing Calendar Analysis...")
     comprehensive_analysis = analyzer.generate_calendar_analysis()
     current_year_analysis = analyzer.generate_current_year_calendar_analysis()
-    
+
     if comprehensive_analysis and current_year_analysis:
         logger.info("✅ Calendar analysis test completed successfully!")
     else:

--- a/data/calendar_analysis.py
+++ b/data/calendar_analysis.py
@@ -18,8 +18,8 @@ import numpy as np
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/cna_analysis.py
+++ b/data/cna_analysis.py
@@ -16,8 +16,8 @@ from typing import Any
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 
@@ -61,7 +61,8 @@ class CNAAnalyzer:
         if epss_file.exists():
             try:
                 with open(epss_file) as f:
-                    return json.load(f)
+                    data: dict[str, dict[str, float]] = json.load(f)
+                    return data
             except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
                 logger.warning(f"    ⚠️ Error loading EPSS data: {e}")
         return {}
@@ -455,11 +456,11 @@ class CNAAnalyzer:
         else:
             logger.warning("    ⚠️ No comprehensive CNA analysis found, generating from scratch...")
             # Generate comprehensive analysis if it doesn't exist
-            comprehensive_data = self.generate_comprehensive_cna_analysis({})
+            comprehensive_data = self.generate_comprehensive_cna_analysis([])
 
         # Filter comprehensive data for current year CNAs
-        current_year_cnas = []
-        cna_counts = {}
+        current_year_cnas: list[dict[str, Any]] = []
+        cna_counts: dict[str, int] = {}
 
         # Process all CNAs from comprehensive analysis
         for cna in comprehensive_data.get("cna_list", []):
@@ -504,7 +505,7 @@ class CNAAnalyzer:
 
                 # Count current year CVEs by CNA
                 mappings = self.load_cna_name_mappings()
-                actual_counts = {}
+                actual_counts: dict[str, int] = {}
 
                 for cve_entry in cve_data:
                     try:

--- a/data/cna_analysis.py
+++ b/data/cna_analysis.py
@@ -3,14 +3,16 @@
 CNA Analysis Module
 Handles all CNA (CVE Numbering Authority) related data processing and analysis
 """
+
 from __future__ import annotations
 
 import json
 from collections import defaultdict
 from dataclasses import dataclass, field
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 from typing import Any
+
 
 try:
     from data.logging_config import get_logger
@@ -23,6 +25,7 @@ logger = get_logger(__name__)
 @dataclass
 class CNAAnalyzer:
     """Handles CNA-specific analysis and data processing"""
+
     base_dir: Path
     cache_dir: Path
     data_dir: Path
@@ -30,7 +33,7 @@ class CNAAnalyzer:
     current_year: int = field(default_factory=lambda: datetime.now().year)
     kev_cve_set: set[str] = field(default_factory=set, init=False)
     epss_data: dict[str, dict[str, float]] = field(default_factory=dict, init=False)
-    
+
     def __post_init__(self) -> None:
         """Convert path arguments and load threat intelligence data."""
         self.base_dir = Path(self.base_dir)
@@ -39,281 +42,295 @@ class CNAAnalyzer:
         # Pre-load threat intelligence data for per-CNA metrics
         self.kev_cve_set = self._load_kev_set()
         self.epss_data = self._load_epss_data()
-    
+
     def _load_kev_set(self) -> set[str]:
         """Load KEV CVE IDs into a set for fast lookup"""
-        kev_file = self.cache_dir / 'known_exploited_vulnerabilities_parsed.json'
+        kev_file = self.cache_dir / "known_exploited_vulnerabilities_parsed.json"
         if kev_file.exists():
             try:
-                with open(kev_file, 'r') as f:
+                with open(kev_file) as f:
                     kev_data = json.load(f)
                 return set(kev_data.keys())
             except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
                 logger.warning(f"    ⚠️ Error loading KEV data: {e}")
         return set()
-    
+
     def _load_epss_data(self) -> dict[str, dict[str, float]]:
         """Load EPSS scores for CVE lookup"""
-        epss_file = self.cache_dir / 'epss_scores-current.json'
+        epss_file = self.cache_dir / "epss_scores-current.json"
         if epss_file.exists():
             try:
-                with open(epss_file, 'r') as f:
+                with open(epss_file) as f:
                     return json.load(f)
             except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
                 logger.warning(f"    ⚠️ Error loading EPSS data: {e}")
         return {}
-        
+
     def load_cna_name_mappings(self) -> dict[str, str]:
         """Load CNA name mappings for UUID resolution"""
-        logger.info(f"    🗺️ Loading CNA name mappings...")
+        logger.info("    🗺️ Loading CNA name mappings...")
         mappings = {}
-        
+
         # Load from cna_name_map.json (UUID to name mappings)
-        cna_name_map_file = self.cache_dir / 'cna_name_map.json'
+        cna_name_map_file = self.cache_dir / "cna_name_map.json"
         if cna_name_map_file.exists():
             try:
-                with open(cna_name_map_file, 'r') as f:
+                with open(cna_name_map_file) as f:
                     data = json.load(f)
-                    
+
                 # Handle different data structures
-                if isinstance(data, dict) and 'data' in data:
+                if isinstance(data, dict) and "data" in data:
                     # Structure: {"data": [...]}
-                    for entry in data['data']:
-                        if isinstance(entry, dict) and 'uuid' in entry and 'name' in entry:
-                            mappings[entry['uuid']] = entry['name']
+                    for entry in data["data"]:
+                        if isinstance(entry, dict) and "uuid" in entry and "name" in entry:
+                            mappings[entry["uuid"]] = entry["name"]
                 elif isinstance(data, list):
                     # Structure: [{"uuid": "...", "name": "..."}, ...]
                     for entry in data:
-                        if isinstance(entry, dict) and 'uuid' in entry and 'name' in entry:
-                            mappings[entry['uuid']] = entry['name']
+                        if isinstance(entry, dict) and "uuid" in entry and "name" in entry:
+                            mappings[entry["uuid"]] = entry["name"]
                 elif isinstance(data, dict):
                     # Direct UUID to name mapping
                     mappings.update(data)
-                    
+
                 logger.info(f"    ✅ Loaded {len(mappings)} UUID mappings from cna_name_map.json")
             except (FileNotFoundError, json.JSONDecodeError, KeyError, OSError) as e:
                 logger.warning(f"    ⚠️ Error loading cna_name_map.json: {e}")
-        
+
         return mappings
-    
+
     def load_official_cna_list(self) -> list[dict[str, Any]]:
         """Load official CNA list for comprehensive analysis"""
-        logger.info(f"    📋 Loading official CNA list...")
+        logger.info("    📋 Loading official CNA list...")
         official_cnas = []
-        
-        cna_list_file = self.cache_dir / 'cna_list.json'
+
+        cna_list_file = self.cache_dir / "cna_list.json"
         if cna_list_file.exists():
             try:
-                with open(cna_list_file, 'r') as f:
+                with open(cna_list_file) as f:
                     data = json.load(f)
-                    
+
                 # Handle different data structures
-                if isinstance(data, dict) and 'data' in data:
-                    official_cnas = data['data']
+                if isinstance(data, dict) and "data" in data:
+                    official_cnas = data["data"]
                 elif isinstance(data, list):
                     official_cnas = data
-                    
+
                 logger.info(f"    ✅ Loaded {len(official_cnas)} official CNAs from cna_list.json")
             except (FileNotFoundError, json.JSONDecodeError, KeyError, OSError) as e:
                 logger.warning(f"    ⚠️ Error loading cna_list.json: {e}")
-        
+
         return official_cnas
-    
+
     def resolve_cna_name(self, source_identifier: str | None, mappings: dict[str, str]) -> str:
         """Resolve CNA name from source identifier using various methods"""
         if not source_identifier:
-            return 'Unknown'
-        
+            return "Unknown"
+
         # Check UUID mapping first
         if source_identifier in mappings:
             return mappings[source_identifier]
-        
+
         # Domain-based mappings
         domain_mappings = {
-            'mitre.org': 'MITRE Corporation',
-            'cve@mitre.org': 'MITRE Corporation',
-            'patchstack.com': 'Patchstack',
-            'wordfence.com': 'Wordfence',
-            'microsoft.com': 'Microsoft Corporation',
-            'apple.com': 'Apple Inc.',
-            'google.com': 'Google LLC',
-            'redhat.com': 'Red Hat Inc.',
-            'debian.org': 'Debian',
-            'ubuntu.com': 'Canonical Ltd.',
-            'suse.com': 'SUSE',
-            'oracle.com': 'Oracle Corporation',
-            'ibm.com': 'IBM Corporation',
-            'cisco.com': 'Cisco Systems Inc.',
-            'adobe.com': 'Adobe Inc.',
-            'mozilla.org': 'Mozilla Foundation'
+            "mitre.org": "MITRE Corporation",
+            "cve@mitre.org": "MITRE Corporation",
+            "patchstack.com": "Patchstack",
+            "wordfence.com": "Wordfence",
+            "microsoft.com": "Microsoft Corporation",
+            "apple.com": "Apple Inc.",
+            "google.com": "Google LLC",
+            "redhat.com": "Red Hat Inc.",
+            "debian.org": "Debian",
+            "ubuntu.com": "Canonical Ltd.",
+            "suse.com": "SUSE",
+            "oracle.com": "Oracle Corporation",
+            "ibm.com": "IBM Corporation",
+            "cisco.com": "Cisco Systems Inc.",
+            "adobe.com": "Adobe Inc.",
+            "mozilla.org": "Mozilla Foundation",
         }
-        
+
         # Check domain mappings
         for domain, name in domain_mappings.items():
             if domain in source_identifier.lower():
                 return name
-        
+
         # Clean up the identifier for display
-        if '@' in source_identifier:
-            domain = source_identifier.split('@')[-1]
-            return domain.replace('.com', '').replace('.org', '').title()
-        
+        if "@" in source_identifier:
+            domain = source_identifier.split("@")[-1]
+            return domain.replace(".com", "").replace(".org", "").title()
+
         # Return cleaned identifier
-        return source_identifier.replace('_', ' ').title()
-    
-    def process_cna_type_distribution(self, official_cnas: list[dict[str, Any]], cna_stats: dict[str, dict[str, Any]]) -> dict[str, Any]:
+        return source_identifier.replace("_", " ").title()
+
+    def process_cna_type_distribution(
+        self, official_cnas: list[dict[str, Any]], cna_stats: dict[str, dict[str, Any]]
+    ) -> dict[str, Any]:
         """Process CNA type distribution from official data"""
-        logger.info(f"    📊 Processing CNA type distribution...")
-        
+        logger.info("    📊 Processing CNA type distribution...")
+
         type_counts: defaultdict[str, int] = defaultdict(int)
-        
+
         # Count types from official CNAs using correct nested structure
         for cna in official_cnas:
             # Use the correct nested path: CNA.type
-            cna_types = cna.get('CNA', {}).get('type', [])
+            cna_types = cna.get("CNA", {}).get("type", [])
             if not isinstance(cna_types, list):
-                cna_types = [cna_types] if cna_types else ['Unknown']
-            
+                cna_types = [cna_types] if cna_types else ["Unknown"]
+
             for cna_type in cna_types:
-                if cna_type and cna_type != 'Unknown':
+                if cna_type and cna_type != "Unknown":
                     type_counts[cna_type] += 1
-        
+
         # Calculate percentages using dict comprehension
         total_official = len(official_cnas)
-        type_percentages = {
-            cna_type: round((count / total_official) * 100, 1)
-            for cna_type, count in type_counts.items()
-        } if total_official > 0 else {}
-        
+        type_percentages = (
+            {cna_type: round((count / total_official) * 100, 1) for cna_type, count in type_counts.items()}
+            if total_official > 0
+            else {}
+        )
+
         # Sort by count (descending)
         sorted_types = sorted(type_counts.items(), key=lambda x: x[1], reverse=True)
-        
+
         return {
-            'type_counts': dict(type_counts),
-            'type_percentages': type_percentages,
-            'sorted_types': sorted_types,
-            'total_official_cnas': total_official
+            "type_counts": dict(type_counts),
+            "type_percentages": type_percentages,
+            "sorted_types": sorted_types,
+            "total_official_cnas": total_official,
         }
-    
+
     def generate_comprehensive_cna_analysis(self, all_year_data: list[dict[str, Any]]) -> dict[str, Any]:
         """Generate comprehensive CNA analysis processing all CVEs and official CNA data"""
-        logger.info(f"  🏢 Generating comprehensive CNA analysis...")
-        
+        logger.info("  🏢 Generating comprehensive CNA analysis...")
+
         # Load CNA mappings and official data
         mappings = self.load_cna_name_mappings()
         official_cnas = self.load_official_cna_list()
-        
+
         # Process CVE data to extract CNA statistics
         cna_stats = {}
-        
+
         # Load CVE data from cache
-        nvd_file = self.cache_dir / 'nvd.json'
+        nvd_file = self.cache_dir / "nvd.json"
         if nvd_file.exists():
             if not self.quiet:
                 logger.info(f"    📂 Loading CVE data from {nvd_file}...")
-            with open(nvd_file, 'r') as f:
+            with open(nvd_file) as f:
                 cve_data = json.load(f)
-            
+
             logger.info(f"    📊 Processing {len(cve_data)} CVEs for comprehensive CNA analysis...")
-            
+
             for i, cve_entry in enumerate(cve_data):
                 if i % 50000 == 0 and i > 0 and not self.quiet:
                     logger.debug(f"    📊 Processed {i:,} CVEs...")
-                
+
                 try:
-                    cve_section = cve_entry.get('cve', {})
-                    cve_id = cve_section.get('id', '')
-                    vuln_status = cve_section.get('vulnStatus', '')
+                    cve_section = cve_entry.get("cve", {})
+                    cve_id = cve_section.get("id", "")
+                    vuln_status = cve_section.get("vulnStatus", "")
 
                     # Keep counting logic aligned with yearly/cve_all outputs.
-                    if 'Rejected' in vuln_status:
+                    if "Rejected" in vuln_status:
                         continue
-                    
-                    if source_identifier := cve_section.get('sourceIdentifier', ''):
+
+                    if source_identifier := cve_section.get("sourceIdentifier", ""):
                         cna_name = self.resolve_cna_name(source_identifier, mappings)
-                        
-                        if cna_name and cna_name != 'Unknown':
+
+                        if cna_name and cna_name != "Unknown":
                             if cna_name not in cna_stats:
                                 cna_stats[cna_name] = {
-                                    'count': 0,
-                                    'first_cve_date': cve_section.get('published', ''),
-                                    'last_cve_date': cve_section.get('published', ''),
-                                    'first_cve_year': None,
-                                    'last_cve_year': None,
-                                    'source_identifier': source_identifier,
+                                    "count": 0,
+                                    "first_cve_date": cve_section.get("published", ""),
+                                    "last_cve_date": cve_section.get("published", ""),
+                                    "first_cve_year": None,
+                                    "last_cve_year": None,
+                                    "source_identifier": source_identifier,
                                     # Threat intelligence per CNA
-                                    'kev_count': 0,
-                                    'epss_high_count': 0,      # EPSS > 0.5
-                                    'epss_elevated_count': 0,  # EPSS > 0.1
-                                    'cwe_counts': {}           # CWE tracking
+                                    "kev_count": 0,
+                                    "epss_high_count": 0,  # EPSS > 0.5
+                                    "epss_elevated_count": 0,  # EPSS > 0.1
+                                    "cwe_counts": {},  # CWE tracking
                                 }
-                            
-                            cna_stats[cna_name]['count'] += 1
-                            
+
+                            cna_stats[cna_name]["count"] += 1
+
                             # Track KEV membership
                             if cve_id in self.kev_cve_set:
-                                cna_stats[cna_name]['kev_count'] += 1
-                            
+                                cna_stats[cna_name]["kev_count"] += 1
+
                             # Track EPSS scores
                             if cve_id in self.epss_data:
-                                epss_score = self.epss_data[cve_id].get('epss_score', 0)
+                                epss_score = self.epss_data[cve_id].get("epss_score", 0)
                                 if epss_score > 0.5:
-                                    cna_stats[cna_name]['epss_high_count'] += 1
+                                    cna_stats[cna_name]["epss_high_count"] += 1
                                 if epss_score > 0.1:
-                                    cna_stats[cna_name]['epss_elevated_count'] += 1
-                            
+                                    cna_stats[cna_name]["epss_elevated_count"] += 1
+
                             # Track CWEs for this CNA
-                            weaknesses = cve_section.get('weaknesses', [])
+                            weaknesses = cve_section.get("weaknesses", [])
                             for weakness in weaknesses:
-                                for desc in weakness.get('description', []):
-                                    cwe_val = desc.get('value', '')
-                                    if cwe_val and cwe_val.startswith('CWE-') and cwe_val != 'CWE-Other':
-                                        cna_stats[cna_name]['cwe_counts'][cwe_val] = cna_stats[cna_name]['cwe_counts'].get(cwe_val, 0) + 1
-                            
+                                for desc in weakness.get("description", []):
+                                    cwe_val = desc.get("value", "")
+                                    if cwe_val and cwe_val.startswith("CWE-") and cwe_val != "CWE-Other":
+                                        cna_stats[cna_name]["cwe_counts"][cwe_val] = (
+                                            cna_stats[cna_name]["cwe_counts"].get(cwe_val, 0) + 1
+                                        )
+
                             # Update date tracking
-                            if pub_date := cve_section.get('published', ''):
-                                if pub_date < cna_stats[cna_name]['first_cve_date'] or not cna_stats[cna_name]['first_cve_date']:
-                                    cna_stats[cna_name]['first_cve_date'] = pub_date
-                                if pub_date > cna_stats[cna_name]['last_cve_date']:
-                                    cna_stats[cna_name]['last_cve_date'] = pub_date
-                                
+                            if pub_date := cve_section.get("published", ""):
+                                if (
+                                    pub_date < cna_stats[cna_name]["first_cve_date"]
+                                    or not cna_stats[cna_name]["first_cve_date"]
+                                ):
+                                    cna_stats[cna_name]["first_cve_date"] = pub_date
+                                if pub_date > cna_stats[cna_name]["last_cve_date"]:
+                                    cna_stats[cna_name]["last_cve_date"] = pub_date
+
                                 # Extract year from CVE ID
-                                if cve_id.startswith('CVE-'):
-                                    year = int(cve_id.split('-')[1])
-                                    if cna_stats[cna_name]['first_cve_year'] is None or year < cna_stats[cna_name]['first_cve_year']:
-                                        cna_stats[cna_name]['first_cve_year'] = year
-                                    if cna_stats[cna_name]['last_cve_year'] is None or year > cna_stats[cna_name]['last_cve_year']:
-                                        cna_stats[cna_name]['last_cve_year'] = year
-                                        
+                                if cve_id.startswith("CVE-"):
+                                    year = int(cve_id.split("-")[1])
+                                    if (
+                                        cna_stats[cna_name]["first_cve_year"] is None
+                                        or year < cna_stats[cna_name]["first_cve_year"]
+                                    ):
+                                        cna_stats[cna_name]["first_cve_year"] = year
+                                    if (
+                                        cna_stats[cna_name]["last_cve_year"] is None
+                                        or year > cna_stats[cna_name]["last_cve_year"]
+                                    ):
+                                        cna_stats[cna_name]["last_cve_year"] = year
+
                 except (KeyError, ValueError, TypeError):
                     continue
-            
+
             if not self.quiet:
                 logger.info(f"    ✅ Processed all CVEs, found {len(cna_stats)} CNAs with published CVEs")
-        
+
         # Create comprehensive CNA list with official data integration
         cna_list = []
-        official_cna_names = {cna.get('organizationName', '') for cna in official_cnas}
-        
+        official_cna_names = {cna.get("organizationName", "") for cna in official_cnas}
+
         # Process CNAs with published CVEs
         for cna_name, stats in cna_stats.items():
             # Find matching official CNA data
             official_info = None
             for cna in official_cnas:
-                if cna.get('organizationName') == cna_name:
+                if cna.get("organizationName") == cna_name:
                     official_info = cna
                     break
-            
+
             # Calculate years active based on CNA designation year (from cnaID) not CVE publication dates
             years_active = 1
             cna_designation_year = None
-            
+
             # Extract CNA designation year from official CNA data if available
-            if official_info and 'cnaID' in official_info:
-                cna_id = official_info['cnaID']
+            if official_info and "cnaID" in official_info:
+                cna_id = official_info["cnaID"]
                 # Extract year from cnaID format like "CNA-2005-0001"
                 try:
-                    if cna_id.startswith('CNA-') and len(cna_id) >= 8:
+                    if cna_id.startswith("CNA-") and len(cna_id) >= 8:
                         year_part = cna_id[4:8]  # Extract "2005" from "CNA-2005-0001"
                         if year_part.isdigit():
                             extracted_year = int(year_part)
@@ -327,254 +344,257 @@ class CNAAnalyzer:
                                 years_active = max(1, self.current_year - 2005 + 1)
                 except (ValueError, IndexError):
                     pass
-            
+
             # Fallback: if no cnaID available, use CVE publication date range (old method)
-            if cna_designation_year is None and stats['first_cve_year'] and stats['last_cve_year']:
-                calculated_years = max(1, stats['last_cve_year'] - stats['first_cve_year'] + 1)
+            if cna_designation_year is None and stats["first_cve_year"] and stats["last_cve_year"]:
+                calculated_years = max(1, stats["last_cve_year"] - stats["first_cve_year"] + 1)
                 # Validate: No CNA can be older than the CNA program (started 2005)
                 # Maximum possible years active = current_year - 2005 + 1
                 max_possible_years = self.current_year - 2005 + 1
                 years_active = min(calculated_years, max_possible_years)
-            
+
             # Calculate days since last CVE
             days_since_last = 0
-            if stats['last_cve_date']:
+            if stats["last_cve_date"]:
                 try:
-                    last_date = datetime.fromisoformat(stats['last_cve_date'].replace('Z', '+00:00'))
+                    last_date = datetime.fromisoformat(stats["last_cve_date"].replace("Z", "+00:00"))
                     days_since_last = (datetime.now() - last_date.replace(tzinfo=None)).days
                 except (ValueError, TypeError):
                     days_since_last = 365  # Default to inactive if date parsing fails
-            
+
             # Determine activity status
-            activity_status = 'Active' if days_since_last < 365 else 'Inactive'
-            
+            activity_status = "Active" if days_since_last < 365 else "Inactive"
+
             cna_entry = {
-                'name': cna_name,
-                'count': stats['count'],
-                'years_active': years_active,
-                'first_cve_year': stats['first_cve_year'],
-                'last_cve_year': stats['last_cve_year'],
-                'first_cve_date': stats['first_cve_date'],
-                'last_cve_date': stats['last_cve_date'],
-                'days_since_last_cve': days_since_last,
-                'activity_status': activity_status,
-                'official_info': official_info,
-                'is_official': cna_name in official_cna_names,
-                'cna_types': official_info.get('CNA', {}).get('type', ['Unknown']) if official_info else ['Unknown'],
+                "name": cna_name,
+                "count": stats["count"],
+                "years_active": years_active,
+                "first_cve_year": stats["first_cve_year"],
+                "last_cve_year": stats["last_cve_year"],
+                "first_cve_date": stats["first_cve_date"],
+                "last_cve_date": stats["last_cve_date"],
+                "days_since_last_cve": days_since_last,
+                "activity_status": activity_status,
+                "official_info": official_info,
+                "is_official": cna_name in official_cna_names,
+                "cna_types": official_info.get("CNA", {}).get("type", ["Unknown"]) if official_info else ["Unknown"],
                 # Threat intelligence metrics
-                'kev_count': stats.get('kev_count', 0),
-                'epss_high_count': stats.get('epss_high_count', 0),
-                'epss_elevated_count': stats.get('epss_elevated_count', 0),
-                'top_cwes': sorted(stats.get('cwe_counts', {}).items(), key=lambda x: x[1], reverse=True)[:5]
+                "kev_count": stats.get("kev_count", 0),
+                "epss_high_count": stats.get("epss_high_count", 0),
+                "epss_elevated_count": stats.get("epss_elevated_count", 0),
+                "top_cwes": sorted(stats.get("cwe_counts", {}).items(), key=lambda x: x[1], reverse=True)[:5],
             }
             cna_list.append(cna_entry)
-        
+
         # Add official CNAs that don't have published CVEs
         for cna in official_cnas:
-            cna_name = cna.get('organizationName', '')
+            cna_name = cna.get("organizationName", "")
             if cna_name and cna_name not in cna_stats:
                 cna_entry = {
-                    'name': cna_name,
-                    'count': 0,
-                    'years_active': 0,
-                    'first_cve_year': None,
-                    'last_cve_year': None,
-                    'first_cve_date': '',
-                    'last_cve_date': '',
-                    'days_since_last_cve': 999999,  # Very high number for never published
-                    'activity_status': 'Never Published',
-                    'official_info': cna,
-                    'is_official': True,
-                    'cna_types': cna.get('CNA', {}).get('type', ['Unknown']),
+                    "name": cna_name,
+                    "count": 0,
+                    "years_active": 0,
+                    "first_cve_year": None,
+                    "last_cve_year": None,
+                    "first_cve_date": "",
+                    "last_cve_date": "",
+                    "days_since_last_cve": 999999,  # Very high number for never published
+                    "activity_status": "Never Published",
+                    "official_info": cna,
+                    "is_official": True,
+                    "cna_types": cna.get("CNA", {}).get("type", ["Unknown"]),
                     # Threat intelligence metrics (zeros for CNAs with no CVEs)
-                    'kev_count': 0,
-                    'epss_high_count': 0,
-                    'epss_elevated_count': 0,
-                    'top_cwes': []
+                    "kev_count": 0,
+                    "epss_high_count": 0,
+                    "epss_elevated_count": 0,
+                    "top_cwes": [],
                 }
                 cna_list.append(cna_entry)
-        
+
         # Sort by CVE count (descending)
-        cna_list.sort(key=lambda x: x['count'], reverse=True)
-        
+        cna_list.sort(key=lambda x: x["count"], reverse=True)
+
         # Process type distribution
         type_distribution = self.process_cna_type_distribution(official_cnas, cna_stats)
-        
+
         # Create comprehensive analysis structure
         analysis_data = {
-            'generated_at': datetime.now().isoformat(),
-            'total_cnas': len(cna_list),
-            'active_cnas': len([c for c in cna_list if c['activity_status'] == 'Active']),
-            'inactive_cnas': len([c for c in cna_list if c['activity_status'] == 'Inactive']),
-            'never_published_cnas': len([c for c in cna_list if c['activity_status'] == 'Never Published']),
-            'official_cnas': len([c for c in cna_list if c['is_official']]),
-            'unofficial_cnas': len([c for c in cna_list if not c['is_official']]),
-            'cna_list': cna_list,
-            'type_distribution': type_distribution
+            "generated_at": datetime.now().isoformat(),
+            "total_cnas": len(cna_list),
+            "active_cnas": len([c for c in cna_list if c["activity_status"] == "Active"]),
+            "inactive_cnas": len([c for c in cna_list if c["activity_status"] == "Inactive"]),
+            "never_published_cnas": len([c for c in cna_list if c["activity_status"] == "Never Published"]),
+            "official_cnas": len([c for c in cna_list if c["is_official"]]),
+            "unofficial_cnas": len([c for c in cna_list if not c["is_official"]]),
+            "cna_list": cna_list,
+            "type_distribution": type_distribution,
         }
-        
+
         # Save to file
-        output_file = self.data_dir / 'cna_analysis.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "cna_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(analysis_data, f, indent=2)
-        
+
         logger.info(f"  ✅ Generated comprehensive CNA analysis with {len(cna_list)} CNAs")
         return analysis_data
-    
+
     def generate_current_year_cna_analysis(self, current_year_data: dict[str, Any]) -> dict[str, Any]:
         """Generate current year CNA analysis by filtering comprehensive analysis for current year CVEs"""
         logger.info(f"    🏢 Generating current year CNA analysis for {self.current_year}...")
-        
+
         # Load comprehensive CNA analysis first to get all CNA data
-        comprehensive_file = self.data_dir / 'cna_analysis.json'
+        comprehensive_file = self.data_dir / "cna_analysis.json"
         comprehensive_data = {}
-        
+
         if comprehensive_file.exists():
-            with open(comprehensive_file, 'r') as f:
+            with open(comprehensive_file) as f:
                 comprehensive_data = json.load(f)
-            logger.info(f"    ✅ Loaded comprehensive CNA analysis with {len(comprehensive_data.get('cna_list', []))} CNAs")
+            logger.info(
+                f"    ✅ Loaded comprehensive CNA analysis with {len(comprehensive_data.get('cna_list', []))} CNAs"
+            )
         else:
-            logger.warning(f"    ⚠️ No comprehensive CNA analysis found, generating from scratch...")
+            logger.warning("    ⚠️ No comprehensive CNA analysis found, generating from scratch...")
             # Generate comprehensive analysis if it doesn't exist
             comprehensive_data = self.generate_comprehensive_cna_analysis({})
-        
+
         # Filter comprehensive data for current year CNAs
         current_year_cnas = []
         cna_counts = {}
-        
+
         # Process all CNAs from comprehensive analysis
-        for cna in comprehensive_data.get('cna_list', []):
-            cna_name = cna.get('name', '')
-            last_cve_year = cna.get('last_cve_year', 0)
-            
+        for cna in comprehensive_data.get("cna_list", []):
+            cna_name = cna.get("name", "")
+            last_cve_year = cna.get("last_cve_year", 0)
+
             # Include CNAs that published CVEs in current year
             if last_cve_year == self.current_year:
                 # Create current year CNA entry
                 current_year_cna = {
-                    'name': cna_name,
-                    'count': 0,  # We'll calculate this from the raw data if available
-                    'rank': len(current_year_cnas) + 1,
-                    'years_active': cna.get('years_active', 1),
-                    'first_cve_year': cna.get('first_cve_year', self.current_year),
-                    'last_cve_year': self.current_year,
-                    'first_cve_date': cna.get('first_cve_date', f'{self.current_year}-01-01T00:00:00'),
-                    'last_cve_date': cna.get('last_cve_date', f'{self.current_year}-12-31T23:59:59'),
-                    'days_since_last_cve': 0,  # Active in current year
-                    'activity_status': 'Active',
-                    'severity_distribution': cna.get('severity_distribution', {}),
-                    'top_cwe_types': cna.get('top_cwe_types', {}),
-                    'official_info': cna.get('official_info'),
-                    'is_official': cna.get('is_official', True),
-                    'cna_types': cna.get('cna_types', ['Unknown']),
+                    "name": cna_name,
+                    "count": 0,  # We'll calculate this from the raw data if available
+                    "rank": len(current_year_cnas) + 1,
+                    "years_active": cna.get("years_active", 1),
+                    "first_cve_year": cna.get("first_cve_year", self.current_year),
+                    "last_cve_year": self.current_year,
+                    "first_cve_date": cna.get("first_cve_date", f"{self.current_year}-01-01T00:00:00"),
+                    "last_cve_date": cna.get("last_cve_date", f"{self.current_year}-12-31T23:59:59"),
+                    "days_since_last_cve": 0,  # Active in current year
+                    "activity_status": "Active",
+                    "severity_distribution": cna.get("severity_distribution", {}),
+                    "top_cwe_types": cna.get("top_cwe_types", {}),
+                    "official_info": cna.get("official_info"),
+                    "is_official": cna.get("is_official", True),
+                    "cna_types": cna.get("cna_types", ["Unknown"]),
                     # Threat intelligence metrics - inherited from comprehensive analysis
-                    'kev_count': cna.get('kev_count', 0),
-                    'epss_high_count': cna.get('epss_high_count', 0),
-                    'epss_elevated_count': cna.get('epss_elevated_count', 0),
-                    'top_cwes': cna.get('top_cwes', [])
+                    "kev_count": cna.get("kev_count", 0),
+                    "epss_high_count": cna.get("epss_high_count", 0),
+                    "epss_elevated_count": cna.get("epss_elevated_count", 0),
+                    "top_cwes": cna.get("top_cwes", []),
                 }
                 current_year_cnas.append(current_year_cna)
-                cna_counts[cna_name] = current_year_cna['count']
-        
+                cna_counts[cna_name] = current_year_cna["count"]
+
         # If we have access to raw CVE data for current year, get actual counts
-        nvd_file = self.cache_dir / 'nvd.json'
+        nvd_file = self.cache_dir / "nvd.json"
         if nvd_file.exists() and len(current_year_cnas) > 0:
             logger.info(f"    📊 Calculating actual CVE counts for {self.current_year}...")
             try:
-                with open(nvd_file, 'r') as f:
+                with open(nvd_file) as f:
                     cve_data = json.load(f)
-                
+
                 # Count current year CVEs by CNA
                 mappings = self.load_cna_name_mappings()
                 actual_counts = {}
-                
+
                 for cve_entry in cve_data:
                     try:
-                        cve_section = cve_entry.get('cve', {})
-                        cve_id = cve_section.get('id', '')
-                        vuln_status = cve_section.get('vulnStatus', '')
-                        
-                        if cve_id.startswith(f'CVE-{self.current_year}-') and 'Rejected' not in vuln_status:
-                            source_identifier = cve_section.get('sourceIdentifier', '')
+                        cve_section = cve_entry.get("cve", {})
+                        cve_id = cve_section.get("id", "")
+                        vuln_status = cve_section.get("vulnStatus", "")
+
+                        if cve_id.startswith(f"CVE-{self.current_year}-") and "Rejected" not in vuln_status:
+                            source_identifier = cve_section.get("sourceIdentifier", "")
                             if source_identifier:
                                 cna_name = self.resolve_cna_name(source_identifier, mappings)
                                 if cna_name:
                                     actual_counts[cna_name] = actual_counts.get(cna_name, 0) + 1
                     except (KeyError, TypeError, AttributeError):
                         continue
-                
+
                 # Update counts in current year CNAs
                 for cna in current_year_cnas:
-                    cna_name = cna['name']
+                    cna_name = cna["name"]
                     if cna_name in actual_counts:
-                        cna['count'] = actual_counts[cna_name]
-                
+                        cna["count"] = actual_counts[cna_name]
+
                 logger.info(f"    ✅ Updated actual CVE counts for {len(actual_counts)} CNAs")
-                
+
             except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
                 logger.warning(f"    ⚠️ Could not calculate actual counts: {e}")
-        
+
         # Sort by count (descending)
-        current_year_cnas.sort(key=lambda x: x['count'], reverse=True)
-        
+        current_year_cnas.sort(key=lambda x: x["count"], reverse=True)
+
         # Update ranks
         for i, cna in enumerate(current_year_cnas):
-            cna['rank'] = i + 1
-        
+            cna["rank"] = i + 1
+
         logger.info(f"    ✅ Found {len(current_year_cnas)} CNAs active in {self.current_year}")
-        
+
         # Calculate type distribution for current year
         type_distribution = self._calculate_type_distribution_for_current_year(current_year_cnas)
-        
+
         # Create comprehensive current year data structure with both cna_list and cna_assigners for compatibility
         current_year_cna_data = {
-            'generated_at': datetime.now().isoformat(),
-            'year': self.current_year,
-            'total_cnas': len(current_year_cnas),
-            'active_cnas': len(current_year_cnas),  # All are active in current year
-            'inactive_cnas': 0,
-            'never_published_cnas': 0,
-            'official_cnas': len([c for c in current_year_cnas if c.get('is_official', True)]),
-            'unofficial_cnas': len([c for c in current_year_cnas if not c.get('is_official', True)]),
-            'cna_list': current_year_cnas,  # For consistency with all-time data
-            'cna_assigners': current_year_cnas,  # For JavaScript compatibility
-            'type_distribution': type_distribution
+            "generated_at": datetime.now().isoformat(),
+            "year": self.current_year,
+            "total_cnas": len(current_year_cnas),
+            "active_cnas": len(current_year_cnas),  # All are active in current year
+            "inactive_cnas": 0,
+            "never_published_cnas": 0,
+            "official_cnas": len([c for c in current_year_cnas if c.get("is_official", True)]),
+            "unofficial_cnas": len([c for c in current_year_cnas if not c.get("is_official", True)]),
+            "cna_list": current_year_cnas,  # For consistency with all-time data
+            "cna_assigners": current_year_cnas,  # For JavaScript compatibility
+            "type_distribution": type_distribution,
         }
-        
+
         # Save current year analysis
-        current_year_file = self.data_dir / 'cna_analysis_current_year.json'
-        with open(current_year_file, 'w') as f:
+        current_year_file = self.data_dir / "cna_analysis_current_year.json"
+        with open(current_year_file, "w") as f:
             json.dump(current_year_cna_data, f, indent=2)
-        
+
         logger.info(f"    📄 Generated enhanced cna_analysis_current_year.json with {len(current_year_cnas)} CNAs")
         return current_year_cna_data
-    
+
     def _calculate_type_distribution_for_current_year(self, cna_assigners: list[dict[str, Any]]) -> dict[str, Any]:
         """Calculate CNA type distribution for current year data"""
         type_counts: defaultdict[str, int] = defaultdict(int)
-        
+
         # Count types from current year CNAs
         for cna in cna_assigners:
-            cna_types = cna.get('cna_types', ['Unknown'])
+            cna_types = cna.get("cna_types", ["Unknown"])
             if not isinstance(cna_types, list):
-                cna_types = [cna_types] if cna_types else ['Unknown']
-            
+                cna_types = [cna_types] if cna_types else ["Unknown"]
+
             for cna_type in cna_types:
                 if cna_type:
                     type_counts[cna_type] += 1
-        
+
         # Calculate percentages using dict comprehension
         total_cnas = len(cna_assigners)
-        type_percentages = {
-            cna_type: round((count / total_cnas) * 100, 1)
-            for cna_type, count in type_counts.items()
-        } if total_cnas > 0 else {}
-        
+        type_percentages = (
+            {cna_type: round((count / total_cnas) * 100, 1) for cna_type, count in type_counts.items()}
+            if total_cnas > 0
+            else {}
+        )
+
         # Sort by count (descending)
         sorted_types = sorted(type_counts.items(), key=lambda x: x[1], reverse=True)
-        
+
         return {
-            'type_counts': dict(type_counts),
-            'type_percentages': type_percentages,
-            'sorted_types': sorted_types,
-            'total_official_cnas': total_cnas
+            "type_counts": dict(type_counts),
+            "type_percentages": type_percentages,
+            "sorted_types": sorted_types,
+            "total_official_cnas": total_cnas,
         }

--- a/data/cpe_analysis.py
+++ b/data/cpe_analysis.py
@@ -3,6 +3,7 @@
 CPE Analysis Module
 Handles all CPE (Common Platform Enumeration) related data processing and analysis
 """
+
 from __future__ import annotations
 
 import json
@@ -11,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
 
 try:
     from data.logging_config import get_logger
@@ -23,400 +25,391 @@ logger = get_logger(__name__)
 @dataclass
 class CPEAnalyzer:
     """Handles CPE-specific analysis and data processing"""
+
     base_dir: Path
     cache_dir: Path
     data_dir: Path
     quiet: bool = False
     current_year: int = field(default_factory=lambda: datetime.now().year)
-    
+
     def __post_init__(self) -> None:
         """Convert path arguments to Path objects if needed."""
         self.base_dir = Path(self.base_dir)
         self.cache_dir = Path(self.cache_dir)
         self.data_dir = Path(self.data_dir)
-    
+
     def extract_cpe_vendor(self, cpe_string: str) -> str:
         """Extract vendor from CPE string (cpe:2.3:a:vendor:product:...)"""
         try:
-            parts = cpe_string.split(':')
+            parts = cpe_string.split(":")
             if len(parts) >= 4:
                 return parts[3]  # vendor is at index 3
-            return 'unknown'
+            return "unknown"
         except (TypeError, AttributeError, IndexError):
-            return 'unknown'
-    
+            return "unknown"
+
     def extract_cpe_product(self, cpe_string: str) -> str:
         """Extract product from CPE string (cpe:2.3:a:vendor:product:...)"""
         try:
-            parts = cpe_string.split(':')
+            parts = cpe_string.split(":")
             if len(parts) >= 5:
                 return parts[4]  # product is at index 4
-            return 'unknown'
+            return "unknown"
         except (TypeError, AttributeError, IndexError):
-            return 'unknown'
-    
+            return "unknown"
+
     def extract_cpe_type(self, cpe_string: str) -> str:
         """Extract CPE type from CPE string (a=application, o=operating_system, h=hardware)"""
         try:
-            parts = cpe_string.split(':')
+            parts = cpe_string.split(":")
             if len(parts) >= 3:
                 cpe_type = parts[2]
-                type_map = {
-                    'a': 'Application',
-                    'o': 'Operating System', 
-                    'h': 'Hardware'
-                }
-                return type_map.get(cpe_type, 'Unknown')
-            return 'Unknown'
+                type_map = {"a": "Application", "o": "Operating System", "h": "Hardware"}
+                return type_map.get(cpe_type, "Unknown")
+            return "Unknown"
         except (TypeError, AttributeError, IndexError):
-            return 'Unknown'
-    
+            return "Unknown"
+
     def generate_cpe_analysis(self, all_year_data: list[dict[str, Any]]) -> dict[str, Any]:
         """Generate CPE analysis across all years"""
         if not self.quiet:
-            logger.info(f"  🔍 Generating CPE analysis...")
-        
+            logger.info("  🔍 Generating CPE analysis...")
+
         # Process raw CVE data to extract CPE information
         cpe_data = self._process_cpe_data_from_cache()
-        
+
         if not cpe_data:
             logger.warning("  ⚠️  No CPE data found, generating minimal analysis")
             return self._generate_minimal_cpe_analysis()
-        
+
         # Analyze CPE patterns
-        cpe_counts = Counter(cpe_data['cpe_list'])
-        vendor_counts = Counter(cpe_data['vendor_list'])
-        product_counts = Counter(cpe_data['product_list'])
-        type_counts = Counter(cpe_data['type_list'])
-        
+        cpe_counts = Counter(cpe_data["cpe_list"])
+        vendor_counts = Counter(cpe_data["vendor_list"])
+        product_counts = Counter(cpe_data["product_list"])
+        type_counts = Counter(cpe_data["type_list"])
+
         # Get top CPEs
         top_cpes = []
         for cpe, count in cpe_counts.most_common(50):
             vendor = self.extract_cpe_vendor(cpe)
             product = self.extract_cpe_product(cpe)
             cpe_type = self.extract_cpe_type(cpe)
-            
-            top_cpes.append({
-                'cpe': cpe,
-                'count': count,
-                'vendor': vendor,
-                'product': product,
-                'type': cpe_type
-            })
-        
+
+            top_cpes.append({"cpe": cpe, "count": count, "vendor": vendor, "product": product, "type": cpe_type})
+
         # Get top vendors
-        top_vendors = [{'vendor': vendor, 'count': count} 
-                      for vendor, count in vendor_counts.most_common(20)]
-        
+        top_vendors = [{"vendor": vendor, "count": count} for vendor, count in vendor_counts.most_common(20)]
+
         # Get top products
-        top_products = [{'product': product, 'count': count} 
-                       for product, count in product_counts.most_common(20)]
-        
+        top_products = [{"product": product, "count": count} for product, count in product_counts.most_common(20)]
+
         # CPE type distribution
-        cpe_type_distribution = [{'type': cpe_type, 'count': count, 'percentage': round(count / len(cpe_data['type_list']) * 100, 1)} 
-                                for cpe_type, count in type_counts.most_common()]
-        
+        cpe_type_distribution = [
+            {"type": cpe_type, "count": count, "percentage": round(count / len(cpe_data["type_list"]) * 100, 1)}
+            for cpe_type, count in type_counts.most_common()
+        ]
+
         # Calculate CVEs with most CPEs
-        cve_cpe_counts = Counter(cpe_data['cve_list'])
+        cve_cpe_counts = Counter(cpe_data["cve_list"])
         cves_with_most_cpes = []
         for cve, cpe_count in cve_cpe_counts.most_common(20):
-            cves_with_most_cpes.append({
-                'cve': cve,
-                'cpe_count': cpe_count
-            })
-        
+            cves_with_most_cpes.append({"cve": cve, "cpe_count": cpe_count})
+
         cpe_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'total_unique_cpes': len(cpe_counts),
-            'total_cpe_entries': len(cpe_data['cpe_list']),
-            'total_cves_with_cpes': len(set(cpe_data['cve_list'])),
-            'total_unique_vendors': len(vendor_counts),
-            'total_unique_products': len(product_counts),
-            'top_cpes': top_cpes,
-            'top_vendors': top_vendors,
-            'top_products': top_products,
-            'cpe_type_distribution': cpe_type_distribution,
-            'cves_with_most_cpes': cves_with_most_cpes,
-            'average_cpes_per_cve': round(len(cpe_data['cpe_list']) / len(set(cpe_data['cve_list'])), 1) if cpe_data['cve_list'] else 0
+            "generated_at": datetime.now().isoformat(),
+            "total_unique_cpes": len(cpe_counts),
+            "total_cpe_entries": len(cpe_data["cpe_list"]),
+            "total_cves_with_cpes": len(set(cpe_data["cve_list"])),
+            "total_unique_vendors": len(vendor_counts),
+            "total_unique_products": len(product_counts),
+            "top_cpes": top_cpes,
+            "top_vendors": top_vendors,
+            "top_products": top_products,
+            "cpe_type_distribution": cpe_type_distribution,
+            "cves_with_most_cpes": cves_with_most_cpes,
+            "average_cpes_per_cve": round(len(cpe_data["cpe_list"]) / len(set(cpe_data["cve_list"])), 1)
+            if cpe_data["cve_list"]
+            else 0,
         }
-        
+
         # Save to file
-        output_file = self.data_dir / 'cpe_analysis.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "cpe_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(cpe_analysis, f, indent=2)
-        
+
         logger.info(f"  ✅ Generated CPE analysis with {len(cpe_counts):,} unique CPEs")
         return cpe_analysis
-    
+
     def generate_current_year_cpe_analysis(self, current_year_data: dict[str, Any]) -> dict[str, Any]:
         """Generate current year CPE analysis"""
-        logger.info(f"    🔍 Generating current year CPE analysis...")
-        
+        logger.info("    🔍 Generating current year CPE analysis...")
+
         # Process current year CPE data from cache
         current_year_cpe_data = self._process_current_year_cpe_data()
-        
+
         if not current_year_cpe_data:
             logger.warning(f"    ⚠️  No CPE data found for {self.current_year}")
             return {}
-        
+
         # Analyze current year CPE patterns
-        cpe_counts = Counter(current_year_cpe_data['cpe_list'])
-        vendor_counts = Counter(current_year_cpe_data['vendor_list'])
-        product_counts = Counter(current_year_cpe_data['product_list'])
-        type_counts = Counter(current_year_cpe_data['type_list'])
-        
+        cpe_counts = Counter(current_year_cpe_data["cpe_list"])
+        vendor_counts = Counter(current_year_cpe_data["vendor_list"])
+        product_counts = Counter(current_year_cpe_data["product_list"])
+        type_counts = Counter(current_year_cpe_data["type_list"])
+
         # Get top CPEs for current year
         top_cpes = []
         for cpe, count in cpe_counts.most_common(30):
             vendor = self.extract_cpe_vendor(cpe)
             product = self.extract_cpe_product(cpe)
             cpe_type = self.extract_cpe_type(cpe)
-            
-            top_cpes.append({
-                'cpe': cpe,
-                'count': count,
-                'vendor': vendor,
-                'product': product,
-                'type': cpe_type
-            })
-        
+
+            top_cpes.append({"cpe": cpe, "count": count, "vendor": vendor, "product": product, "type": cpe_type})
+
         # Get top vendors for current year
-        top_vendors = [{'vendor': vendor, 'count': count} 
-                      for vendor, count in vendor_counts.most_common(15)]
-        
+        top_vendors = [{"vendor": vendor, "count": count} for vendor, count in vendor_counts.most_common(15)]
+
         # Get top products for current year
-        top_products = [{'product': product, 'count': count} 
-                       for product, count in product_counts.most_common(15)]
-        
+        top_products = [{"product": product, "count": count} for product, count in product_counts.most_common(15)]
+
         # CPE type distribution for current year
-        cpe_type_distribution = [{'type': cpe_type, 'count': count, 'percentage': round(count / len(current_year_cpe_data['type_list']) * 100, 1)} 
-                                for cpe_type, count in type_counts.most_common()]
-        
+        cpe_type_distribution = [
+            {
+                "type": cpe_type,
+                "count": count,
+                "percentage": round(count / len(current_year_cpe_data["type_list"]) * 100, 1),
+            }
+            for cpe_type, count in type_counts.most_common()
+        ]
+
         # Calculate CVEs with most CPEs for current year
-        cve_cpe_counts = Counter(current_year_cpe_data['cve_list'])
+        cve_cpe_counts = Counter(current_year_cpe_data["cve_list"])
         cves_with_most_cpes = []
         for cve, cpe_count in cve_cpe_counts.most_common(20):
-            cves_with_most_cpes.append({
-                'cve': cve,
-                'cpe_count': cpe_count
-            })
-        
+            cves_with_most_cpes.append({"cve": cve, "cpe_count": cpe_count})
+
         current_year_cpe_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'year': self.current_year,
-            'total_unique_cpes': len(cpe_counts),
-            'total_cpe_entries': len(current_year_cpe_data['cpe_list']),
-            'total_cves_with_cpes': len(set(current_year_cpe_data['cve_list'])),
-            'total_unique_vendors': len(vendor_counts),
-            'total_unique_products': len(product_counts),
-            'top_cpes': top_cpes,
-            'top_vendors': top_vendors,
-            'top_products': top_products,
-            'cpe_type_distribution': cpe_type_distribution,
-            'cves_with_most_cpes': cves_with_most_cpes,
-            'average_cpes_per_cve': round(len(current_year_cpe_data['cpe_list']) / len(set(current_year_cpe_data['cve_list'])), 1) if current_year_cpe_data['cve_list'] else 0
+            "generated_at": datetime.now().isoformat(),
+            "year": self.current_year,
+            "total_unique_cpes": len(cpe_counts),
+            "total_cpe_entries": len(current_year_cpe_data["cpe_list"]),
+            "total_cves_with_cpes": len(set(current_year_cpe_data["cve_list"])),
+            "total_unique_vendors": len(vendor_counts),
+            "total_unique_products": len(product_counts),
+            "top_cpes": top_cpes,
+            "top_vendors": top_vendors,
+            "top_products": top_products,
+            "cpe_type_distribution": cpe_type_distribution,
+            "cves_with_most_cpes": cves_with_most_cpes,
+            "average_cpes_per_cve": round(
+                len(current_year_cpe_data["cpe_list"]) / len(set(current_year_cpe_data["cve_list"])), 1
+            )
+            if current_year_cpe_data["cve_list"]
+            else 0,
         }
-        
+
         # Save current year analysis
-        current_year_file = self.data_dir / 'cpe_analysis_current_year.json'
-        with open(current_year_file, 'w') as f:
+        current_year_file = self.data_dir / "cpe_analysis_current_year.json"
+        with open(current_year_file, "w") as f:
             json.dump(current_year_cpe_analysis, f, indent=2)
-        
+
         logger.info(f"    ✅ Generated current year CPE analysis with {len(cpe_counts)} unique CPEs")
         return current_year_cpe_analysis
-    
+
     def _process_cpe_data_from_cache(self) -> dict[str, list[str]] | None:
         """Process CPE data from cached nvd.json file"""
-        nvd_file = self.cache_dir / 'nvd.json'
-        
+        nvd_file = self.cache_dir / "nvd.json"
+
         if not nvd_file.exists():
             logger.warning(f"    ⚠️  NVD cache file not found: {nvd_file}")
             return None
-        
+
         if not self.quiet:
             logger.info(f"    📂 Processing CPE data from {nvd_file}")
-        
+
         cpe_list = []
         vendor_list = []
         product_list = []
         type_list = []
         cve_list = []
-        
+
         try:
-            with open(nvd_file, 'r', encoding='utf-8') as f:
+            with open(nvd_file, encoding="utf-8") as f:
                 if not self.quiet:
                     logger.info(f"    📂 Loading NVD data from {nvd_file}...")
                 nvd_data = json.load(f)
-                
+
                 # Handle different possible data structures
                 cve_items = []
                 if isinstance(nvd_data, list):
                     cve_items = nvd_data
                 elif isinstance(nvd_data, dict):
                     # Check for common NVD data structure patterns
-                    if 'CVE_Items' in nvd_data:
-                        cve_items = nvd_data['CVE_Items']
-                    elif 'vulnerabilities' in nvd_data:
-                        cve_items = nvd_data['vulnerabilities']
+                    if "CVE_Items" in nvd_data:
+                        cve_items = nvd_data["CVE_Items"]
+                    elif "vulnerabilities" in nvd_data:
+                        cve_items = nvd_data["vulnerabilities"]
                     else:
                         # Assume it's a single CVE item
                         cve_items = [nvd_data]
-                
+
                 if not self.quiet:
                     logger.info(f"    📊 Processing {len(cve_items):,} CVE records...")
-                
+
                 for idx, cve_item in enumerate(cve_items):
                     if idx % 50000 == 0 and idx > 0 and not self.quiet:
                         logger.debug(f"    📊 Processed {idx:,} CVE records...")
-                    
+
                     try:
                         # Handle different CVE data structures
                         cve_data = cve_item
-                        if 'cve' in cve_item:
-                            cve_data = cve_item['cve']
-                        
-                        cve_id = cve_data.get('id', cve_data.get('CVE_data_meta', {}).get('ID', ''))
-                        
+                        if "cve" in cve_item:
+                            cve_data = cve_item["cve"]
+
+                        cve_id = cve_data.get("id", cve_data.get("CVE_data_meta", {}).get("ID", ""))
+
                         # Extract CPE data from configurations
-                        configurations = cve_data.get('configurations', [])
-                        if not configurations and 'configurations' in cve_item:
-                            configurations = cve_item['configurations']
-                        
+                        configurations = cve_data.get("configurations", [])
+                        if not configurations and "configurations" in cve_item:
+                            configurations = cve_item["configurations"]
+
                         for config in configurations:
-                            for node in config.get('nodes', []):
-                                if 'cpeMatch' in node:
-                                    for cpe_match in node['cpeMatch']:
-                                        if cpe_match.get('vulnerable', False):
-                                            if cpe_string := cpe_match.get('criteria', ''):
+                            for node in config.get("nodes", []):
+                                if "cpeMatch" in node:
+                                    for cpe_match in node["cpeMatch"]:
+                                        if cpe_match.get("vulnerable", False):
+                                            if cpe_string := cpe_match.get("criteria", ""):
                                                 cpe_list.append(cpe_string)
                                                 cve_list.append(cve_id)
                                                 vendor_list.append(self.extract_cpe_vendor(cpe_string))
                                                 product_list.append(self.extract_cpe_product(cpe_string))
                                                 type_list.append(self.extract_cpe_type(cpe_string))
-                    
+
                     except (KeyError, TypeError, AttributeError):
                         continue
-        
+
         except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
             logger.error(f"    ❌ Error processing NVD file: {e}")
             return None
-        
+
         if not self.quiet:
             logger.info(f"    ✅ Processed {len(cpe_list):,} CPE entries from {len(set(cve_list)):,} CVEs")
-        
+
         return {
-            'cpe_list': cpe_list,
-            'vendor_list': vendor_list,
-            'product_list': product_list,
-            'type_list': type_list,
-            'cve_list': cve_list
+            "cpe_list": cpe_list,
+            "vendor_list": vendor_list,
+            "product_list": product_list,
+            "type_list": type_list,
+            "cve_list": cve_list,
         }
-    
+
     def _process_current_year_cpe_data(self) -> dict[str, list[str]] | None:
         """Process CPE data for current year only"""
-        nvd_file = self.cache_dir / 'nvd.json'
-        
+        nvd_file = self.cache_dir / "nvd.json"
+
         if not nvd_file.exists():
             logger.warning(f"    ⚠️  NVD cache file not found: {nvd_file}")
             return None
-        
+
         if not self.quiet:
             logger.info(f"    📂 Processing current year CPE data from {nvd_file}")
-        
+
         cpe_list = []
         vendor_list = []
         product_list = []
         type_list = []
         cve_list = []
-        
+
         try:
-            with open(nvd_file, 'r', encoding='utf-8') as f:
+            with open(nvd_file, encoding="utf-8") as f:
                 if not self.quiet:
                     logger.info(f"    📂 Loading NVD data for current year from {nvd_file}...")
                 nvd_data = json.load(f)
-                
+
                 # Handle different possible data structures
                 cve_items = []
                 if isinstance(nvd_data, list):
                     cve_items = nvd_data
                 elif isinstance(nvd_data, dict):
                     # Check for common NVD data structure patterns
-                    if 'CVE_Items' in nvd_data:
-                        cve_items = nvd_data['CVE_Items']
-                    elif 'vulnerabilities' in nvd_data:
-                        cve_items = nvd_data['vulnerabilities']
+                    if "CVE_Items" in nvd_data:
+                        cve_items = nvd_data["CVE_Items"]
+                    elif "vulnerabilities" in nvd_data:
+                        cve_items = nvd_data["vulnerabilities"]
                     else:
                         # Assume it's a single CVE item
                         cve_items = [nvd_data]
-                
+
                 if not self.quiet:
                     logger.info(f"    📊 Processing {len(cve_items):,} CVE records for current year...")
-                
+
                 for idx, cve_item in enumerate(cve_items):
                     if idx % 50000 == 0 and idx > 0 and not self.quiet:
                         logger.debug(f"    📊 Processed {idx:,} CVE records for current year...")
-                    
+
                     try:
                         # Handle different CVE data structures
                         cve_data = cve_item
-                        if 'cve' in cve_item:
-                            cve_data = cve_item['cve']
-                        
-                        cve_id = cve_data.get('id', cve_data.get('CVE_data_meta', {}).get('ID', ''))
-                        
+                        if "cve" in cve_item:
+                            cve_data = cve_item["cve"]
+
+                        cve_id = cve_data.get("id", cve_data.get("CVE_data_meta", {}).get("ID", ""))
+
                         # Check if CVE is from current year
-                        published_date = cve_data.get('published', cve_data.get('publishedDate', ''))
+                        published_date = cve_data.get("published", cve_data.get("publishedDate", ""))
                         if not published_date.startswith(str(self.current_year)):
                             continue
-                        
+
                         # Extract CPE data from configurations
-                        configurations = cve_data.get('configurations', [])
-                        if not configurations and 'configurations' in cve_item:
-                            configurations = cve_item['configurations']
-                        
+                        configurations = cve_data.get("configurations", [])
+                        if not configurations and "configurations" in cve_item:
+                            configurations = cve_item["configurations"]
+
                         for config in configurations:
-                            for node in config.get('nodes', []):
-                                if 'cpeMatch' in node:
-                                    for cpe_match in node['cpeMatch']:
-                                        if cpe_match.get('vulnerable', False):
-                                            if cpe_string := cpe_match.get('criteria', ''):
+                            for node in config.get("nodes", []):
+                                if "cpeMatch" in node:
+                                    for cpe_match in node["cpeMatch"]:
+                                        if cpe_match.get("vulnerable", False):
+                                            if cpe_string := cpe_match.get("criteria", ""):
                                                 cpe_list.append(cpe_string)
                                                 cve_list.append(cve_id)
                                                 vendor_list.append(self.extract_cpe_vendor(cpe_string))
                                                 product_list.append(self.extract_cpe_product(cpe_string))
                                                 type_list.append(self.extract_cpe_type(cpe_string))
-                    
+
                     except (KeyError, TypeError, AttributeError):
                         continue
-        
+
         except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
             logger.error(f"    ❌ Error processing NVD file for current year: {e}")
             return None
-        
+
         if not self.quiet:
-            logger.info(f"    ✅ Processed {len(cpe_list):,} CPE entries from {len(set(cve_list)):,} CVEs for {self.current_year}")
-        
+            logger.info(
+                f"    ✅ Processed {len(cpe_list):,} CPE entries from {len(set(cve_list)):,} CVEs for {self.current_year}"
+            )
+
         return {
-            'cpe_list': cpe_list,
-            'vendor_list': vendor_list,
-            'product_list': product_list,
-            'type_list': type_list,
-            'cve_list': cve_list
+            "cpe_list": cpe_list,
+            "vendor_list": vendor_list,
+            "product_list": product_list,
+            "type_list": type_list,
+            "cve_list": cve_list,
         }
-    
+
     def _generate_minimal_cpe_analysis(self) -> dict[str, Any]:
         """Generate minimal CPE analysis when no data is available"""
         return {
-            'generated_at': datetime.now().isoformat(),
-            'total_unique_cpes': 0,
-            'total_cpe_entries': 0,
-            'total_cves_with_cpes': 0,
-            'total_unique_vendors': 0,
-            'total_unique_products': 0,
-            'top_cpes': [],
-            'top_vendors': [],
-            'top_products': [],
-            'cpe_type_distribution': [],
-            'cves_with_most_cpes': [],
-            'average_cpes_per_cve': 0
+            "generated_at": datetime.now().isoformat(),
+            "total_unique_cpes": 0,
+            "total_cpe_entries": 0,
+            "total_cves_with_cpes": 0,
+            "total_unique_vendors": 0,
+            "total_unique_products": 0,
+            "top_cpes": [],
+            "top_vendors": [],
+            "top_products": [],
+            "cpe_type_distribution": [],
+            "cves_with_most_cpes": [],
+            "average_cpes_per_cve": 0,
         }

--- a/data/cpe_analysis.py
+++ b/data/cpe_analysis.py
@@ -16,8 +16,8 @@ from typing import Any
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/cve_v5_processor.py
+++ b/data/cve_v5_processor.py
@@ -53,8 +53,8 @@ except ImportError:
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/cve_v5_processor.py
+++ b/data/cve_v5_processor.py
@@ -32,9 +32,7 @@ from download_cve_data import CVEDataDownloader
 try:
     from data.fast_json import dump_json_fast, load_json_fast
     from data.optimized_processing import (
-        classify_cna_type_fast,
         collect_cve_files,
-        parse_cve_record_fast,
         process_cve_batch,
     )
 
@@ -43,9 +41,7 @@ except ImportError:
     try:
         from fast_json import dump_json_fast, load_json_fast
         from optimized_processing import (
-            classify_cna_type_fast,
             collect_cve_files,
-            parse_cve_record_fast,
             process_cve_batch,
         )
 
@@ -964,9 +960,7 @@ class CVEV5Processor:
         cna_list = []
         total_cnas = len(all_cna_stats)
         print(f"  📊 Building CNA list from {total_cnas} CNAs...")
-        processed_cnas = 0
-        for org_id, stats in all_cna_stats.items():
-            processed_cnas += 1
+        for processed_cnas, (org_id, stats) in enumerate(all_cna_stats.items(), start=1):
             if processed_cnas % 50 == 0:
                 print(f"    📈 Processing CNA {processed_cnas}/{total_cnas}...")
             # Calculate years active using publication dates

--- a/data/cve_v5_processor.py
+++ b/data/cve_v5_processor.py
@@ -516,8 +516,8 @@ class CVEV5Processor:
                     if not isinstance(description, dict):
                         continue
 
-                    for field in ("cweId", "cweID", "value", "description"):
-                        value = description.get(field)
+                    for key in ("cweId", "cweID", "value", "description"):
+                        value = description.get(key)
                         if not isinstance(value, str):
                             continue
                         if match := cwe_pattern.search(value):
@@ -749,7 +749,7 @@ class CVEV5Processor:
                 if pub_date:
                     try:
                         pub_year = datetime.fromisoformat(pub_date.replace('Z', '+00:00')).year
-                    except:
+                    except (AttributeError, TypeError, ValueError):
                         pass
                 
                 # Update CNA statistics

--- a/data/cve_v5_processor.py
+++ b/data/cve_v5_processor.py
@@ -10,10 +10,10 @@ Performance Optimizations (2026-01-10):
 - Pre-compiled patterns for CNA type classification
 - Memory-efficient aggregation with __slots__
 """
+
 from __future__ import annotations
 
 import json
-import os
 import re
 import shutil
 import subprocess
@@ -21,32 +21,34 @@ from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
-from functools import lru_cache
 from multiprocessing import cpu_count
 from pathlib import Path
 from typing import Any
 
 from download_cve_data import CVEDataDownloader
 
+
 # Import optimized utilities if available
 try:
-    from data.fast_json import load_json_fast, dump_json_fast
+    from data.fast_json import dump_json_fast, load_json_fast
     from data.optimized_processing import (
-        collect_cve_files,
-        process_cve_batch,
         classify_cna_type_fast,
+        collect_cve_files,
         parse_cve_record_fast,
+        process_cve_batch,
     )
+
     OPTIMIZED_AVAILABLE = True
 except ImportError:
     try:
-        from fast_json import load_json_fast, dump_json_fast
+        from fast_json import dump_json_fast, load_json_fast
         from optimized_processing import (
-            collect_cve_files,
-            process_cve_batch,
             classify_cna_type_fast,
+            collect_cve_files,
             parse_cve_record_fast,
+            process_cve_batch,
         )
+
         OPTIMIZED_AVAILABLE = True
     except ImportError:
         OPTIMIZED_AVAILABLE = False
@@ -64,6 +66,7 @@ logger = get_logger(__name__)
 @dataclass
 class CVEV5Processor:
     """Processes CVE V5 list data for authoritative CNA analysis"""
+
     base_dir: Path
     cache_dir: Path
     data_dir: Path
@@ -72,13 +75,13 @@ class CVEV5Processor:
     v5_cache_dir: Path = field(init=False)
     epss_mapping: dict[str, dict[str, float]] = field(default_factory=dict, init=False)
     kev_cve_set: set[str] = field(default_factory=set, init=False)
-    
+
     def __post_init__(self) -> None:
         """Convert paths and load threat intelligence data."""
         self.base_dir = Path(self.base_dir)
         self.cache_dir = Path(self.cache_dir)
         self.data_dir = Path(self.data_dir)
-        self.v5_cache_dir = self.cache_dir / 'cvelistV5'
+        self.v5_cache_dir = self.cache_dir / "cvelistV5"
         # Load threat intelligence data
         self._load_epss_mapping()
         self._load_kev_set()
@@ -103,7 +106,7 @@ class CVEV5Processor:
                 if OPTIMIZED_AVAILABLE and load_json_fast:
                     self.epss_mapping = load_json_fast(epss_json_path)
                 else:
-                    with open(epss_json_path, 'r', encoding='utf-8') as f:
+                    with open(epss_json_path, encoding="utf-8") as f:
                         self.epss_mapping = json.load(f)
                 if not self.quiet:
                     logger.info(f"  ✅ Loaded EPSS mapping for {len(self.epss_mapping):,} CVEs")
@@ -117,14 +120,14 @@ class CVEV5Processor:
 
     def _load_kev_set(self) -> None:
         """Load KEV CVE IDs into a set for fast lookup"""
-        kev_file = self.cache_dir / 'known_exploited_vulnerabilities_parsed.json'
+        kev_file = self.cache_dir / "known_exploited_vulnerabilities_parsed.json"
         if kev_file.exists():
             try:
                 # Use optimized JSON loading if available
                 if OPTIMIZED_AVAILABLE and load_json_fast:
                     kev_data = load_json_fast(kev_file)
                 else:
-                    with open(kev_file, 'r') as f:
+                    with open(kev_file) as f:
                         kev_data = json.load(f)
                 self.kev_cve_set = set(kev_data.keys())
                 if not self.quiet:
@@ -139,89 +142,128 @@ class CVEV5Processor:
 
         # CNA type classification patterns
         self.cna_type_patterns = {
-            'Vendor': [
-                'microsoft', 'apple', 'google', 'oracle', 'cisco', 'adobe', 'ibm',
-                'redhat', 'canonical', 'suse', 'debian', 'ubuntu', 'mozilla',
-                'vmware', 'intel', 'amd', 'nvidia', 'qualcomm', 'samsung',
-                'huawei', 'lenovo', 'hp', 'dell', 'netapp', 'citrix'
+            "Vendor": [
+                "microsoft",
+                "apple",
+                "google",
+                "oracle",
+                "cisco",
+                "adobe",
+                "ibm",
+                "redhat",
+                "canonical",
+                "suse",
+                "debian",
+                "ubuntu",
+                "mozilla",
+                "vmware",
+                "intel",
+                "amd",
+                "nvidia",
+                "qualcomm",
+                "samsung",
+                "huawei",
+                "lenovo",
+                "hp",
+                "dell",
+                "netapp",
+                "citrix",
             ],
-            'Security Researcher': [
-                'patchstack', 'wordfence', 'vuldb', 'zerodayinitiative', 'trendmicro',
-                'rapid7', 'tenable', 'qualys', 'checkmarx', 'veracode'
+            "Security Researcher": [
+                "patchstack",
+                "wordfence",
+                "vuldb",
+                "zerodayinitiative",
+                "trendmicro",
+                "rapid7",
+                "tenable",
+                "qualys",
+                "checkmarx",
+                "veracode",
             ],
-            'CERT': [
-                'cert', 'cisa', 'ncsc', 'jpcert', 'kr-cert', 'au-cert',
-                'ca-cert', 'de-cert', 'fr-cert', 'nl-cert'
+            "CERT": [
+                "cert",
+                "cisa",
+                "ncsc",
+                "jpcert",
+                "kr-cert",
+                "au-cert",
+                "ca-cert",
+                "de-cert",
+                "fr-cert",
+                "nl-cert",
             ],
-            'Government': [
-                'cisa', 'nist', 'dhs', 'gov', 'mil', 'defense',
-                'homeland', 'treasury', 'energy', 'state'
+            "Government": ["cisa", "nist", "dhs", "gov", "mil", "defense", "homeland", "treasury", "energy", "state"],
+            "Academic": ["edu", "university", "college", "research", "institute", "academic", "school", "campus"],
+            "Open Source": [
+                "github",
+                "gitlab",
+                "apache",
+                "eclipse",
+                "linux",
+                "kernel",
+                "gnu",
+                "fsf",
+                "oss",
+                "opensource",
             ],
-            'Academic': [
-                'edu', 'university', 'college', 'research', 'institute',
-                'academic', 'school', 'campus'
-            ],
-            'Open Source': [
-                'github', 'gitlab', 'apache', 'eclipse', 'linux', 'kernel',
-                'gnu', 'fsf', 'oss', 'opensource'
-            ]
         }
-        
+
     def clone_or_update_cve_v5_repo(self) -> bool:
         """Clone or update the CVE V5 repository with shallow clone"""
-        logger.info(f"  📥 Setting up CVE V5 repository...")
-        
+        logger.info("  📥 Setting up CVE V5 repository...")
+
         if self.v5_cache_dir.exists():
             # Check if it's a valid git repository
-            git_dir = self.v5_cache_dir / '.git'
+            git_dir = self.v5_cache_dir / ".git"
             if not git_dir.exists():
-                logger.warning(f"    ⚠️ Invalid git repository, re-cloning...")
+                logger.warning("    ⚠️ Invalid git repository, re-cloning...")
                 shutil.rmtree(self.v5_cache_dir)
                 return self._clone_fresh_repo()
-            
-            logger.info(f"    🔄 Updating existing CVE V5 repository...")
+
+            logger.info("    🔄 Updating existing CVE V5 repository...")
             try:
                 # First try a simple git pull (no --depth flag for existing repos)
                 result = subprocess.run(
-                    ['git', 'pull', 'origin', 'main'],
+                    ["git", "pull", "origin", "main"],
                     cwd=self.v5_cache_dir,
                     capture_output=True,
                     text=True,
-                    timeout=300
+                    timeout=300,
                 )
                 if result.returncode == 0:
-                    logger.info(f"    ✅ Successfully updated CVE V5 repository")
+                    logger.info("    ✅ Successfully updated CVE V5 repository")
                     return True
                 else:
                     # Try to reset and pull if there are conflicts
-                    logger.info(f"    🔄 Pull failed, trying reset and pull...")
+                    logger.info("    🔄 Pull failed, trying reset and pull...")
                     reset_result = subprocess.run(
-                        ['git', 'reset', '--hard', 'origin/main'],
+                        ["git", "reset", "--hard", "origin/main"],
                         cwd=self.v5_cache_dir,
                         capture_output=True,
                         text=True,
-                        timeout=60
+                        timeout=60,
                     )
                     if reset_result.returncode == 0:
                         pull_result = subprocess.run(
-                            ['git', 'pull', 'origin', 'main'],
+                            ["git", "pull", "origin", "main"],
                             cwd=self.v5_cache_dir,
                             capture_output=True,
                             text=True,
-                            timeout=300
+                            timeout=300,
                         )
                         if pull_result.returncode == 0:
-                            logger.info(f"    ✅ Successfully updated CVE V5 repository after reset")
+                            logger.info("    ✅ Successfully updated CVE V5 repository after reset")
                             return True
-                    
+
                     # Only re-clone as last resort
-                    logger.warning(f"    ⚠️ All update attempts failed, re-cloning as last resort...")
+                    logger.warning("    ⚠️ All update attempts failed, re-cloning as last resort...")
                     logger.debug(f"    📝 Git pull error: {result.stderr}")
                     shutil.rmtree(self.v5_cache_dir)
                     return self._clone_fresh_repo()
-                    
+
             except subprocess.TimeoutExpired:
-                logger.warning(f"    ⏰ Git pull timed out, repository may be up to date")
+                logger.warning("    ⏰ Git pull timed out, repository may be up to date")
                 return True  # Don't re-clone on timeout, assume it's working
             except (subprocess.SubprocessError, OSError) as e:
                 logger.warning(f"    ⚠️ Update failed with exception: {e}")
@@ -230,81 +272,83 @@ class CVEV5Processor:
                     shutil.rmtree(self.v5_cache_dir)
                     return self._clone_fresh_repo()
                 else:
-                    logger.debug(f"    📝 Assuming repository is usable despite error")
+                    logger.debug("    📝 Assuming repository is usable despite error")
                     return True
         else:
             return self._clone_fresh_repo()
-    
+
     def _clone_fresh_repo(self) -> bool:
         """Clone fresh CVE V5 repository"""
-        logger.info(f"    📦 Cloning CVE V5 repository (shallow clone)...")
+        logger.info("    📦 Cloning CVE V5 repository (shallow clone)...")
         try:
             # Ensure cache directory exists
             self.cache_dir.mkdir(parents=True, exist_ok=True)
-            
+
             # Shallow clone with depth=1 to minimize data transfer
-            result = subprocess.run([
-                'git', 'clone', 
-                '--depth=1',
-                '--single-branch',
-                'https://github.com/CVEProject/cvelistV5.git',
-                str(self.v5_cache_dir)
-            ], capture_output=True, text=True, timeout=600)
-            
+            result = subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--depth=1",
+                    "--single-branch",
+                    "https://github.com/CVEProject/cvelistV5.git",
+                    str(self.v5_cache_dir),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+
             if result.returncode == 0:
-                logger.info(f"    ✅ Successfully cloned CVE V5 repository")
+                logger.info("    ✅ Successfully cloned CVE V5 repository")
                 return True
             else:
                 logger.error(f"    ❌ Failed to clone CVE V5 repository: {result.stderr}")
                 return False
-                
+
         except subprocess.TimeoutExpired:
-            logger.error(f"    ❌ Clone operation timed out")
+            logger.error("    ❌ Clone operation timed out")
             return False
         except (subprocess.SubprocessError, OSError) as e:
             logger.error(f"    ❌ Clone failed: {e}")
             return False
-    
+
     def get_repo_stats(self) -> dict[str, Any] | None:
         """Get basic statistics about the cloned repository"""
         if not self.v5_cache_dir.exists():
             return None
-            
-        cves_dir = self.v5_cache_dir / 'cves'
+
+        cves_dir = self.v5_cache_dir / "cves"
         if not cves_dir.exists():
             return None
-            
-        stats = {
-            'total_years': 0,
-            'total_cves': 0,
-            'years_available': []
-        }
-        
+
+        stats = {"total_years": 0, "total_cves": 0, "years_available": []}
+
         for year_dir in sorted(cves_dir.iterdir()):
             if year_dir.is_dir() and year_dir.name.isdigit():
                 year = int(year_dir.name)
-                stats['years_available'].append(year)
-                stats['total_years'] += 1
-                
+                stats["years_available"].append(year)
+                stats["total_years"] += 1
+
                 # Count CVE files in this year (handle nested structure)
                 year_cve_count = 0
                 for subdir in year_dir.iterdir():
                     if subdir.is_dir():
-                        cve_files = list(subdir.glob('CVE-*.json'))
+                        cve_files = list(subdir.glob("CVE-*.json"))
                         year_cve_count += len(cve_files)
-                stats['total_cves'] += year_cve_count
-        
+                stats["total_cves"] += year_cve_count
+
         return stats
-    
+
     def classify_cna_type(self, org_id: str, short_name: str) -> list[str]:
         """Classify CNA type based on organization ID and short name"""
         # Combine org_id and short_name for pattern matching
         search_text = f"{org_id} {short_name}".lower()
-        
+
         # Special cases first
-        if 'mitre' in search_text:
-            return ['Program']  # MITRE is the CVE Program
-        
+        if "mitre" in search_text:
+            return ["Program"]  # MITRE is the CVE Program
+
         # Check patterns for each type
         matched_types = []
         for cna_type, patterns in self.cna_type_patterns.items():
@@ -312,108 +356,151 @@ class CVEV5Processor:
                 if pattern in search_text:
                     matched_types.append(cna_type)
                     break  # Only add each type once
-        
+
         # If no specific type matched, use comprehensive inference patterns
         if not matched_types:
             # Academic institutions
-            if any(domain in search_text for domain in ['.edu', 'university', 'college', 'institut', 'research', 'academic', 'school']):
-                matched_types.append('Academic')
+            if any(
+                domain in search_text
+                for domain in [".edu", "university", "college", "institut", "research", "academic", "school"]
+            ):
+                matched_types.append("Academic")
             # Government and military
-            elif any(gov in search_text for gov in ['.gov', '.mil', 'government', 'cisa', 'nist', 'dhs', 'defense', 'homeland']):
-                matched_types.append('Government')
+            elif any(
+                gov in search_text
+                for gov in [".gov", ".mil", "government", "cisa", "nist", "dhs", "defense", "homeland"]
+            ):
+                matched_types.append("Government")
             # CERT and security organizations
-            elif any(cert in search_text for cert in ['cert', 'csirt', 'security', 'cyber']):
-                matched_types.append('CERT')
+            elif any(cert in search_text for cert in ["cert", "csirt", "security", "cyber"]):
+                matched_types.append("CERT")
             # Open source projects and repositories
-            elif any(oss in search_text for oss in ['github', 'gitlab', 'apache', 'linux', 'kernel', 'gnu', 'eclipse', 'mozilla', 'debian', 'ubuntu', 'redhat', 'canonical', 'suse']):
-                matched_types.append('Open Source')
+            elif any(
+                oss in search_text
+                for oss in [
+                    "github",
+                    "gitlab",
+                    "apache",
+                    "linux",
+                    "kernel",
+                    "gnu",
+                    "eclipse",
+                    "mozilla",
+                    "debian",
+                    "ubuntu",
+                    "redhat",
+                    "canonical",
+                    "suse",
+                ]
+            ):
+                matched_types.append("Open Source")
             # Security researchers and vulnerability research
-            elif any(sec in search_text for sec in ['vulnerability', 'exploit', 'security', 'research', 'bug', 'bounty', 'pentest', 'audit']):
-                matched_types.append('Security Researcher')
+            elif any(
+                sec in search_text
+                for sec in ["vulnerability", "exploit", "security", "research", "bug", "bounty", "pentest", "audit"]
+            ):
+                matched_types.append("Security Researcher")
             # Technology vendors (broad patterns)
-            elif any(vendor in search_text for vendor in ['corp', 'inc', 'ltd', 'llc', 'gmbh', 'co', 'company', 'tech', 'software', 'systems', 'solutions', 'technologies']):
-                matched_types.append('Vendor')
+            elif any(
+                vendor in search_text
+                for vendor in [
+                    "corp",
+                    "inc",
+                    "ltd",
+                    "llc",
+                    "gmbh",
+                    "co",
+                    "company",
+                    "tech",
+                    "software",
+                    "systems",
+                    "solutions",
+                    "technologies",
+                ]
+            ):
+                matched_types.append("Vendor")
             # Email domain-based classification
-            elif '@' in search_text:
-                domain = search_text.split('@')[-1] if '@' in search_text else ''
-                if '.edu' in domain or 'university' in domain:
-                    matched_types.append('Academic')
-                elif '.gov' in domain or '.mil' in domain:
-                    matched_types.append('Government')
-                elif any(tech in domain for tech in ['.com', '.org', '.net', 'tech', 'software', 'systems']):
-                    matched_types.append('Vendor')
+            elif "@" in search_text:
+                domain = search_text.split("@")[-1] if "@" in search_text else ""
+                if ".edu" in domain or "university" in domain:
+                    matched_types.append("Academic")
+                elif ".gov" in domain or ".mil" in domain:
+                    matched_types.append("Government")
+                elif any(tech in domain for tech in [".com", ".org", ".net", "tech", "software", "systems"]):
+                    matched_types.append("Vendor")
                 else:
-                    matched_types.append('Other')
+                    matched_types.append("Other")
             else:
                 # Final fallback - assume most are vendors/organizations
-                matched_types.append('Vendor')
-        
-        return matched_types if matched_types else ['Vendor']
-    
+                matched_types.append("Vendor")
+
+        return matched_types if matched_types else ["Vendor"]
+
     def calculate_enhanced_statistics(self, cna_list: list[dict[str, Any]]) -> dict[str, Any]:
         """Calculate enhanced statistics for CNA analysis"""
         if not cna_list:
             return {}
-        
-        total_cves = sum(cna['count'] for cna in cna_list)
+
+        total_cves = sum(cna["count"] for cna in cna_list)
         total_cnas = len(cna_list)
-        
+
         # Market concentration (top 5 CNAs)
-        top_5_cves = sum(cna['count'] for cna in cna_list[:5])
+        top_5_cves = sum(cna["count"] for cna in cna_list[:5])
         market_concentration = (top_5_cves / total_cves * 100) if total_cves > 0 else 0
-        
+
         # High volume CNAs (1000+ CVEs)
-        high_volume_cnas = len([cna for cna in cna_list if cna['count'] >= 1000])
-        
+        high_volume_cnas = len([cna for cna in cna_list if cna["count"] >= 1000])
+
         # Activity statistics
-        active_cnas = len([cna for cna in cna_list if cna['activity_status'] == 'Active'])
+        active_cnas = len([cna for cna in cna_list if cna["activity_status"] == "Active"])
         inactive_cnas = total_cnas - active_cnas
-        
+
         # Years active statistics
-        years_active_list = [cna['years_active'] for cna in cna_list if cna.get('years_active', 0) > 0]
+        years_active_list = [cna["years_active"] for cna in cna_list if cna.get("years_active", 0) > 0]
         median_years_active = 0
         if years_active_list:
             years_active_list.sort()
             n = len(years_active_list)
-            median_years_active = years_active_list[n // 2] if n % 2 == 1 else (years_active_list[n // 2 - 1] + years_active_list[n // 2]) / 2
-        
+            median_years_active = (
+                years_active_list[n // 2]
+                if n % 2 == 1
+                else (years_active_list[n // 2 - 1] + years_active_list[n // 2]) / 2
+            )
+
         # Type distribution
         type_counts = defaultdict(int)
         for cna in cna_list:
-            cna_types = cna.get('cna_types', ['Other'])
+            cna_types = cna.get("cna_types", ["Other"])
             for cna_type in cna_types:
                 type_counts[cna_type] += 1
-        
+
         # Convert to format expected by JavaScript using comprehensions
         # JavaScript expects: type_distribution.sorted_types and type_distribution.type_percentages
         sorted_type_items = sorted(type_counts.items(), key=lambda x: x[1], reverse=True)
-        
+
         # List comprehension for sorted_types (JavaScript expects [type, count] pairs)
         sorted_types = [[cna_type, count] for cna_type, count in sorted_type_items]
-        
+
         # Dict comprehension for type_percentages
         type_percentages = {
             cna_type: round((count / total_cnas * 100), 1) if total_cnas > 0 else 0
             for cna_type, count in sorted_type_items
         }
-        
+
         # Create the structure expected by JavaScript
-        type_distribution = {
-            'sorted_types': sorted_types,
-            'type_percentages': type_percentages
-        }
-        
+        type_distribution = {"sorted_types": sorted_types, "type_percentages": type_percentages}
+
         return {
-            'total_cves': total_cves,
-            'total_cnas': total_cnas,
-            'active_cnas': active_cnas,
-            'inactive_cnas': inactive_cnas,
-            'high_volume_cnas': high_volume_cnas,
-            'market_concentration': round(market_concentration, 1),
-            'median_years_active': round(median_years_active, 1),
-            'type_distribution': type_distribution
+            "total_cves": total_cves,
+            "total_cnas": total_cnas,
+            "active_cnas": active_cnas,
+            "inactive_cnas": inactive_cnas,
+            "high_volume_cnas": high_volume_cnas,
+            "market_concentration": round(market_concentration, 1),
+            "median_years_active": round(median_years_active, 1),
+            "type_distribution": type_distribution,
         }
-    
+
     @staticmethod
     def _severity_from_score(score: float) -> str:
         """Normalize numeric score to a severity bucket."""
@@ -529,344 +616,350 @@ class CVEV5Processor:
     def parse_cve_v5_record(self, cve_file_path: Path, include_enrichment: bool = False):
         """Parse a single CVE v5 record and extract CNA information."""
         try:
-            with open(cve_file_path, 'r', encoding='utf-8') as f:
+            with open(cve_file_path, encoding="utf-8") as f:
                 cve_data = json.load(f)
-            
+
             # Extract CVE metadata
-            cve_metadata = cve_data.get('cveMetadata', {})
-            cve_id = cve_metadata.get('cveId', '')
-            state = cve_metadata.get('state', '')
-            
+            cve_metadata = cve_data.get("cveMetadata", {})
+            cve_id = cve_metadata.get("cveId", "")
+            state = cve_metadata.get("state", "")
+
             # Skip REJECTED CVEs - they don't represent valid vulnerabilities
-            if state == 'REJECTED':
+            if state == "REJECTED":
                 return None
-            
+
             # Extract CNA information from V5 format
-            assigner_org_id = cve_metadata.get('assignerOrgId', '')
-            assigner_short_name = cve_metadata.get('assignerShortName', '')
-            
+            assigner_org_id = cve_metadata.get("assignerOrgId", "")
+            assigner_short_name = cve_metadata.get("assignerShortName", "")
+
             # Extract publication date
-            date_published = cve_metadata.get('datePublished', '')
-            date_updated = cve_metadata.get('dateUpdated', '')
-            
+            date_published = cve_metadata.get("datePublished", "")
+            date_updated = cve_metadata.get("dateUpdated", "")
+
             # Use publication date for accurate CNA activity tracking
             # (date_updated reflects record modifications, not actual CVE assignment)
             pub_date = date_published if date_published else date_updated
-            
+
             record = {
-                'cve_id': cve_id,
-                'assigner_org_id': assigner_org_id,
-                'assigner_short_name': assigner_short_name,
-                'date_published': date_published,
-                'date_updated': date_updated,
-                'publication_date': pub_date,
-                'year': int(cve_id.split('-')[1]) if cve_id.startswith('CVE-') else None
+                "cve_id": cve_id,
+                "assigner_org_id": assigner_org_id,
+                "assigner_short_name": assigner_short_name,
+                "date_published": date_published,
+                "date_updated": date_updated,
+                "publication_date": pub_date,
+                "year": int(cve_id.split("-")[1]) if cve_id.startswith("CVE-") else None,
             }
 
             if include_enrichment:
-                record['severity_bucket'] = self._extract_cvss_severity_bucket(cve_data)
-                record['cwes'] = self._extract_cwes_from_containers(cve_data)
+                record["severity_bucket"] = self._extract_cvss_severity_bucket(cve_data)
+                record["cwes"] = self._extract_cwes_from_containers(cve_data)
 
             # Attach EPSS enrichment if available
             if cve_id and self.epss_mapping:
                 epss = self.epss_mapping.get(cve_id)
                 if epss:
-                    record['epss_score'] = epss.get('epss_score')
-                    record['epss_percentile'] = epss.get('epss_percentile')
+                    record["epss_score"] = epss.get("epss_score")
+                    record["epss_percentile"] = epss.get("epss_percentile")
 
             return record
-            
+
         except (json.JSONDecodeError, KeyError, ValueError, OSError) as e:
             logger.warning(f"    ⚠️ Error parsing {cve_file_path}: {e}")
             return None
-    
+
     def process_all_cves_single_pass(self, use_parallel: bool = True):
         """Process ALL CVE records in a single pass, tracking by publication year.
-        
+
         Performance optimizations (2026-01-10):
         - Parallel file processing with multiprocessing (2-4x speedup)
         - Optimized file collection using os.scandir (2x faster than glob)
         - Batched I/O to reduce syscall overhead
-        
+
         This is more efficient than processing year-by-year since:
         1. CVE folder year (e.g., cves/2024/) is the CVE ID year, not publication year
         2. A CVE-2024-XXXX might be published in 2025
         3. Single pass = read each file once instead of multiple times
-        
+
         Args:
             use_parallel: Use parallel processing (default: True)
         """
-        print(f"  📊 Processing all CVE files in single pass...")
-        
-        cves_dir = self.v5_cache_dir / 'cves'
-        
+        print("  📊 Processing all CVE files in single pass...")
+
+        cves_dir = self.v5_cache_dir / "cves"
+
         # Use optimized parallel processing if available and enabled
         if use_parallel and OPTIMIZED_AVAILABLE and collect_cve_files is not None:
-            print(f"  ⚡ Using optimized parallel processing...")
-            
+            print("  ⚡ Using optimized parallel processing...")
+
             # Use optimized file collection (os.scandir is 2x faster than glob)
             all_cve_files = collect_cve_files(cves_dir)
             total_files = len(all_cve_files)
             print(f"  📊 Found {total_files:,} total CVE files to process")
-            
+
             if total_files == 0:
                 return {}
-            
+
             # Determine optimal worker count
             max_workers = max(1, cpu_count() - 1)
             batch_size = 500
-            
+
             print(f"  🔄 Processing with {max_workers} workers, batch size {batch_size}...")
-            
+
             # Create batches
-            batches = [
-                [str(f) for f in all_cve_files[i:i + batch_size]]
-                for i in range(0, total_files, batch_size)
-            ]
-            
+            batches = [[str(f) for f in all_cve_files[i : i + batch_size]] for i in range(0, total_files, batch_size)]
+
             # Initialize aggregated stats
-            all_cna_stats = defaultdict(lambda: {
-                'count': 0,
-                'cves': [],
-                'first_date': None,
-                'last_date': None,
-                'first_year': None,
-                'last_year': None,
-                'assigner_org_id': '',
-                'assigner_short_name': '',
-                'cves_by_pub_year': defaultdict(int),
-                'kev_count': 0,
-                'epss_high_count': 0,
-                'epss_elevated_count': 0,
-                'cwe_counts': defaultdict(int)
-            })
-            
+            all_cna_stats = defaultdict(
+                lambda: {
+                    "count": 0,
+                    "cves": [],
+                    "first_date": None,
+                    "last_date": None,
+                    "first_year": None,
+                    "last_year": None,
+                    "assigner_org_id": "",
+                    "assigner_short_name": "",
+                    "cves_by_pub_year": defaultdict(int),
+                    "kev_count": 0,
+                    "epss_high_count": 0,
+                    "epss_elevated_count": 0,
+                    "cwe_counts": defaultdict(int),
+                }
+            )
+
             processed = 0
-            
+
             # Process in parallel
             with ProcessPoolExecutor(max_workers=max_workers) as executor:
-                futures = {
-                    executor.submit(process_cve_batch, batch): i 
-                    for i, batch in enumerate(batches)
-                }
-                
+                futures = {executor.submit(process_cve_batch, batch): i for i, batch in enumerate(batches)}
+
                 for future in as_completed(futures):
                     try:
                         records = future.result()
-                        
+
                         for record in records:
-                            org_id = record.get('org_id', '')
+                            org_id = record.get("org_id", "")
                             if not org_id:
                                 continue
-                            
-                            cve_id = record.get('cve_id', '')
-                            pub_date = record.get('pub_date', '')
-                            pub_year = record.get('pub_year')
-                            
+
+                            cve_id = record.get("cve_id", "")
+                            pub_date = record.get("pub_date", "")
+                            pub_year = record.get("pub_year")
+
                             # Update CNA statistics
-                            all_cna_stats[org_id]['count'] += 1
-                            all_cna_stats[org_id]['cves'].append(cve_id)
-                            all_cna_stats[org_id]['assigner_org_id'] = org_id
-                            all_cna_stats[org_id]['assigner_short_name'] = record.get('short_name', '')
-                            
+                            all_cna_stats[org_id]["count"] += 1
+                            all_cna_stats[org_id]["cves"].append(cve_id)
+                            all_cna_stats[org_id]["assigner_org_id"] = org_id
+                            all_cna_stats[org_id]["assigner_short_name"] = record.get("short_name", "")
+
                             # Track by PUBLICATION year
                             if pub_year:
-                                all_cna_stats[org_id]['cves_by_pub_year'][pub_year] += 1
-                            
+                                all_cna_stats[org_id]["cves_by_pub_year"][pub_year] += 1
+
                             # Track date ranges
                             if pub_date:
-                                if not all_cna_stats[org_id]['first_date'] or pub_date < all_cna_stats[org_id]['first_date']:
-                                    all_cna_stats[org_id]['first_date'] = pub_date
-                                    all_cna_stats[org_id]['first_year'] = pub_year
-                                if not all_cna_stats[org_id]['last_date'] or pub_date > all_cna_stats[org_id]['last_date']:
-                                    all_cna_stats[org_id]['last_date'] = pub_date
-                                    all_cna_stats[org_id]['last_year'] = pub_year
-                            
+                                if (
+                                    not all_cna_stats[org_id]["first_date"]
+                                    or pub_date < all_cna_stats[org_id]["first_date"]
+                                ):
+                                    all_cna_stats[org_id]["first_date"] = pub_date
+                                    all_cna_stats[org_id]["first_year"] = pub_year
+                                if (
+                                    not all_cna_stats[org_id]["last_date"]
+                                    or pub_date > all_cna_stats[org_id]["last_date"]
+                                ):
+                                    all_cna_stats[org_id]["last_date"] = pub_date
+                                    all_cna_stats[org_id]["last_year"] = pub_year
+
                             # Track KEV membership
                             if cve_id in self.kev_cve_set:
-                                all_cna_stats[org_id]['kev_count'] += 1
-                            
+                                all_cna_stats[org_id]["kev_count"] += 1
+
                             # Track EPSS scores
                             if cve_id in self.epss_mapping:
-                                epss_score = self.epss_mapping[cve_id].get('epss_score', 0)
+                                epss_score = self.epss_mapping[cve_id].get("epss_score", 0)
                                 if epss_score > 0.5:
-                                    all_cna_stats[org_id]['epss_high_count'] += 1
+                                    all_cna_stats[org_id]["epss_high_count"] += 1
                                 if epss_score > 0.1:
-                                    all_cna_stats[org_id]['epss_elevated_count'] += 1
-                        
+                                    all_cna_stats[org_id]["epss_elevated_count"] += 1
+
                         processed += len(records)
                         if processed % 10000 < batch_size:
                             print(f"    📈 Processed {processed:,}/{total_files:,} files...")
-                            
+
                     except Exception as e:
                         logger.warning(f"Batch processing error: {e}")
-            
+
             print(f"  ✅ Processed {processed:,} CVE files, found {len(all_cna_stats)} unique CNAs")
             return dict(all_cna_stats)
-        
+
         # Fallback to original single-threaded processing
-        print(f"  📊 Using single-threaded processing (install optimized_processing for parallel)...")
-        
+        print("  📊 Using single-threaded processing (install optimized_processing for parallel)...")
+
         # Initialize CNA stats with publication year tracking
-        all_cna_stats = defaultdict(lambda: {
-            'count': 0,
-            'cves': [],
-            'first_date': None,
-            'last_date': None,
-            'first_year': None,
-            'last_year': None,
-            'assigner_org_id': '',
-            'assigner_short_name': '',
-            'cves_by_pub_year': defaultdict(int),  # Keyed by PUBLICATION year
-            'kev_count': 0,
-            'epss_high_count': 0,
-            'epss_elevated_count': 0,
-            'cwe_counts': defaultdict(int)
-        })
-        
+        all_cna_stats = defaultdict(
+            lambda: {
+                "count": 0,
+                "cves": [],
+                "first_date": None,
+                "last_date": None,
+                "first_year": None,
+                "last_year": None,
+                "assigner_org_id": "",
+                "assigner_short_name": "",
+                "cves_by_pub_year": defaultdict(int),  # Keyed by PUBLICATION year
+                "kev_count": 0,
+                "epss_high_count": 0,
+                "epss_elevated_count": 0,
+                "cwe_counts": defaultdict(int),
+            }
+        )
+
         # Collect all CVE files from all year directories
         all_cve_files = []
-        
+
         for year_dir in sorted(cves_dir.iterdir()):
             if year_dir.is_dir() and year_dir.name.isdigit():
                 for subdir in year_dir.iterdir():
                     if subdir.is_dir():
-                        all_cve_files.extend(subdir.glob('CVE-*.json'))
-        
+                        all_cve_files.extend(subdir.glob("CVE-*.json"))
+
         total_files = len(all_cve_files)
         print(f"  📊 Found {total_files} total CVE files to process")
-        
+
         processed = 0
         for cve_file in all_cve_files:
             cve_record = self.parse_cve_v5_record(cve_file)
-            if cve_record and cve_record['assigner_org_id']:
-                org_id = cve_record['assigner_org_id']
-                cve_id = cve_record['cve_id']
-                pub_date = cve_record['publication_date']
-                
+            if cve_record and cve_record["assigner_org_id"]:
+                org_id = cve_record["assigner_org_id"]
+                cve_id = cve_record["cve_id"]
+                pub_date = cve_record["publication_date"]
+
                 # Extract publication year from the date
                 pub_year = None
                 if pub_date:
                     try:
-                        pub_year = datetime.fromisoformat(pub_date.replace('Z', '+00:00')).year
+                        pub_year = datetime.fromisoformat(pub_date.replace("Z", "+00:00")).year
                     except (AttributeError, TypeError, ValueError):
                         pass
-                
+
                 # Update CNA statistics
-                all_cna_stats[org_id]['count'] += 1
-                all_cna_stats[org_id]['cves'].append(cve_id)
-                all_cna_stats[org_id]['assigner_org_id'] = org_id
-                all_cna_stats[org_id]['assigner_short_name'] = cve_record['assigner_short_name']
-                
+                all_cna_stats[org_id]["count"] += 1
+                all_cna_stats[org_id]["cves"].append(cve_id)
+                all_cna_stats[org_id]["assigner_org_id"] = org_id
+                all_cna_stats[org_id]["assigner_short_name"] = cve_record["assigner_short_name"]
+
                 # Track by PUBLICATION year (not CVE ID year)
                 if pub_year:
-                    all_cna_stats[org_id]['cves_by_pub_year'][pub_year] += 1
-                
+                    all_cna_stats[org_id]["cves_by_pub_year"][pub_year] += 1
+
                 # Track date ranges
                 if pub_date:
-                    if not all_cna_stats[org_id]['first_date'] or pub_date < all_cna_stats[org_id]['first_date']:
-                        all_cna_stats[org_id]['first_date'] = pub_date
-                        all_cna_stats[org_id]['first_year'] = pub_year
-                    if not all_cna_stats[org_id]['last_date'] or pub_date > all_cna_stats[org_id]['last_date']:
-                        all_cna_stats[org_id]['last_date'] = pub_date
-                        all_cna_stats[org_id]['last_year'] = pub_year
-                
+                    if not all_cna_stats[org_id]["first_date"] or pub_date < all_cna_stats[org_id]["first_date"]:
+                        all_cna_stats[org_id]["first_date"] = pub_date
+                        all_cna_stats[org_id]["first_year"] = pub_year
+                    if not all_cna_stats[org_id]["last_date"] or pub_date > all_cna_stats[org_id]["last_date"]:
+                        all_cna_stats[org_id]["last_date"] = pub_date
+                        all_cna_stats[org_id]["last_year"] = pub_year
+
                 # Track KEV membership inline
                 if cve_id in self.kev_cve_set:
-                    all_cna_stats[org_id]['kev_count'] += 1
-                
+                    all_cna_stats[org_id]["kev_count"] += 1
+
                 # Track EPSS scores inline
                 if cve_id in self.epss_mapping:
-                    epss_score = self.epss_mapping[cve_id].get('epss_score', 0)
+                    epss_score = self.epss_mapping[cve_id].get("epss_score", 0)
                     if epss_score > 0.5:
-                        all_cna_stats[org_id]['epss_high_count'] += 1
+                        all_cna_stats[org_id]["epss_high_count"] += 1
                     if epss_score > 0.1:
-                        all_cna_stats[org_id]['epss_elevated_count'] += 1
-            
+                        all_cna_stats[org_id]["epss_elevated_count"] += 1
+
             processed += 1
             if processed % 10000 == 0:
                 print(f"    📈 Processed {processed}/{total_files} files...")
-        
+
         print(f"  ✅ Processed {processed} CVE files, found {len(all_cna_stats)} unique CNAs")
         return dict(all_cna_stats)
 
     def process_year_data(self, year):
         """Process all CVE records for a specific year"""
         logger.info(f"    📅 Processing CVE data for year {year}...")
-        
-        year_dir = self.v5_cache_dir / 'cves' / str(year)
+
+        year_dir = self.v5_cache_dir / "cves" / str(year)
         if not year_dir.exists():
             logger.warning(f"    ⚠️ No data found for year {year}")
             return {}
-        
-        cna_stats = defaultdict(lambda: {
-            'count': 0,
-            'cves': [],
-            'first_date': None,
-            'last_date': None,
-            'assigner_org_id': '',
-            'assigner_short_name': ''
-        })
-        
+
+        cna_stats = defaultdict(
+            lambda: {
+                "count": 0,
+                "cves": [],
+                "first_date": None,
+                "last_date": None,
+                "assigner_org_id": "",
+                "assigner_short_name": "",
+            }
+        )
+
         # CVE V5 has nested directory structure (0xxx, 1xxx, etc.)
         cve_files = []
         for subdir in year_dir.iterdir():
             if subdir.is_dir():
-                cve_files.extend(subdir.glob('CVE-*.json'))
-        
+                cve_files.extend(subdir.glob("CVE-*.json"))
+
         total_files = len(cve_files)
         processed = 0
-        
+
         if not self.quiet:
             logger.info(f"    📊 Found {total_files} CVE files for {year}")
-        
+
         for cve_file in cve_files:
             cve_record = self.parse_cve_v5_record(cve_file)
-            if cve_record and cve_record['assigner_org_id']:
-                org_id = cve_record['assigner_org_id']
-                
+            if cve_record and cve_record["assigner_org_id"]:
+                org_id = cve_record["assigner_org_id"]
+
                 # Update CNA statistics
-                cna_stats[org_id]['count'] += 1
-                cna_stats[org_id]['cves'].append(cve_record['cve_id'])
-                cna_stats[org_id]['assigner_org_id'] = org_id
-                cna_stats[org_id]['assigner_short_name'] = cve_record['assigner_short_name']
-                
+                cna_stats[org_id]["count"] += 1
+                cna_stats[org_id]["cves"].append(cve_record["cve_id"])
+                cna_stats[org_id]["assigner_org_id"] = org_id
+                cna_stats[org_id]["assigner_short_name"] = cve_record["assigner_short_name"]
+
                 # Track date ranges
-                pub_date = cve_record['publication_date']
+                pub_date = cve_record["publication_date"]
                 if pub_date:
-                    if not cna_stats[org_id]['first_date'] or pub_date < cna_stats[org_id]['first_date']:
-                        cna_stats[org_id]['first_date'] = pub_date
-                    if not cna_stats[org_id]['last_date'] or pub_date > cna_stats[org_id]['last_date']:
-                        cna_stats[org_id]['last_date'] = pub_date
-            
+                    if not cna_stats[org_id]["first_date"] or pub_date < cna_stats[org_id]["first_date"]:
+                        cna_stats[org_id]["first_date"] = pub_date
+                    if not cna_stats[org_id]["last_date"] or pub_date > cna_stats[org_id]["last_date"]:
+                        cna_stats[org_id]["last_date"] = pub_date
+
             processed += 1
             if processed % 1000 == 0 and not self.quiet:
                 logger.debug(f"    📈 Processed {processed}/{total_files} files...")
-        
+
         if not self.quiet:
             logger.info(f"    ✅ Processed {processed} CVE files, found {len(cna_stats)} CNAs for {year}")
         return dict(cna_stats)
-    
+
     def generate_comprehensive_cna_analysis(self) -> dict[str, Any] | None:
         """Generate comprehensive CNA analysis using CVE V5 data as single source of truth"""
-        logger.info(f"  🏢 Generating comprehensive CNA analysis from CVE V5 data...")
-        
+        logger.info("  🏢 Generating comprehensive CNA analysis from CVE V5 data...")
+
         # Ensure we have the latest CVE V5 data
         if not self.clone_or_update_cve_v5_repo():
-            logger.error(f"  ❌ Failed to setup CVE V5 repository")
+            logger.error("  ❌ Failed to setup CVE V5 repository")
             return None
-        
+
         # Get repository statistics
         repo_stats = self.get_repo_stats()
         if not repo_stats:
-            logger.error(f"  ❌ Failed to get repository statistics")
+            logger.error("  ❌ Failed to get repository statistics")
             return None
-            
+
         print(f"  📊 Repository contains {repo_stats['total_cves']} CVEs across {repo_stats['total_years']} years")
-        
+
         # Use single-pass processing (reads each file once, tracks by publication year)
         all_cna_stats = self.process_all_cves_single_pass()
-        
+
         # Convert to final format
         cna_list = []
         total_cnas = len(all_cna_stats)
@@ -880,14 +973,14 @@ class CVEV5Processor:
             years_active_count = 1
             first_pub_year = None
             last_pub_year = None
-            if stats['first_date']:
+            if stats["first_date"]:
                 try:
-                    first_pub_year = datetime.fromisoformat(stats['first_date'].replace('Z', '+00:00')).year
+                    first_pub_year = datetime.fromisoformat(stats["first_date"].replace("Z", "+00:00")).year
                 except (ValueError, TypeError):
                     pass
-            if stats['last_date']:
+            if stats["last_date"]:
                 try:
-                    last_pub_year = datetime.fromisoformat(stats['last_date'].replace('Z', '+00:00')).year
+                    last_pub_year = datetime.fromisoformat(stats["last_date"].replace("Z", "+00:00")).year
                 except (ValueError, TypeError):
                     pass
             if first_pub_year and last_pub_year:
@@ -895,304 +988,314 @@ class CVEV5Processor:
 
             # Calculate days since last CVE
             days_since_last = 365  # Default to inactive
-            if stats['last_date']:
+            if stats["last_date"]:
                 try:
-                    last_date = datetime.fromisoformat(stats['last_date'].replace('Z', '+00:00'))
+                    last_date = datetime.fromisoformat(stats["last_date"].replace("Z", "+00:00"))
                     days_since_last = (datetime.now(last_date.tzinfo) - last_date).days
                 except (ValueError, TypeError):
                     days_since_last = 365
 
             # Determine activity status
-            activity_status = 'Active' if days_since_last < 365 else 'Inactive'
+            activity_status = "Active" if days_since_last < 365 else "Inactive"
 
             # Classify CNA type
-            cna_types = self.classify_cna_type(org_id, stats['assigner_short_name'])
+            cna_types = self.classify_cna_type(org_id, stats["assigner_short_name"])
 
             # KEV and EPSS are already tracked inline during single-pass processing
-            kev_count = stats.get('kev_count', 0)
-            epss_high_count = stats.get('epss_high_count', 0)
-            epss_elevated_count = stats.get('epss_elevated_count', 0)
+            kev_count = stats.get("kev_count", 0)
+            epss_high_count = stats.get("epss_high_count", 0)
+            epss_elevated_count = stats.get("epss_elevated_count", 0)
 
             # Severity and CWE aggregation is expensive - use simpler approach
             severity_distribution = {}
             top_cwe_types = {}
-            
+
             cna_entry = {
-                'name': stats['assigner_short_name'] or org_id,
-                'assigner_org_id': org_id,
-                'count': stats['count'],
-                'years_active': years_active_count,
-                'first_cve_year': first_pub_year,
-                'last_cve_year': last_pub_year,
-                'first_cve_date': stats['first_date'],
-                'last_cve_date': stats['last_date'],
-                'days_since_last_cve': days_since_last,
-                'activity_status': activity_status,
-                'is_official': True,  # All CVE V5 records are from official CNAs
-                'cna_types': cna_types,  # Add CNA type classification
-                'cves_by_year': dict(stats.get('cves_by_pub_year', {})),  # Use publication year
-                'years_active_list': [first_pub_year, last_pub_year] if first_pub_year and last_pub_year else [],
+                "name": stats["assigner_short_name"] or org_id,
+                "assigner_org_id": org_id,
+                "count": stats["count"],
+                "years_active": years_active_count,
+                "first_cve_year": first_pub_year,
+                "last_cve_year": last_pub_year,
+                "first_cve_date": stats["first_date"],
+                "last_cve_date": stats["last_date"],
+                "days_since_last_cve": days_since_last,
+                "activity_status": activity_status,
+                "is_official": True,  # All CVE V5 records are from official CNAs
+                "cna_types": cna_types,  # Add CNA type classification
+                "cves_by_year": dict(stats.get("cves_by_pub_year", {})),  # Use publication year
+                "years_active_list": [first_pub_year, last_pub_year] if first_pub_year and last_pub_year else [],
                 # Add placeholder fields for compatibility
-                'severity_distribution': severity_distribution,
-                'top_cwe_types': top_cwe_types,
+                "severity_distribution": severity_distribution,
+                "top_cwe_types": top_cwe_types,
                 # Threat intelligence metrics
-                'kev_count': kev_count,
-                'epss_high_count': epss_high_count,
-                'epss_elevated_count': epss_elevated_count,
-                'top_cwes': list(top_cwe_types.items())[:5]  # For template compatibility
+                "kev_count": kev_count,
+                "epss_high_count": epss_high_count,
+                "epss_elevated_count": epss_elevated_count,
+                "top_cwes": list(top_cwe_types.items())[:5],  # For template compatibility
             }
             cna_list.append(cna_entry)
-        
+
         # Sort by CVE count (descending)
-        cna_list.sort(key=lambda x: x['count'], reverse=True)
-        
+        cna_list.sort(key=lambda x: x["count"], reverse=True)
+
         # Add ranks
         for i, cna in enumerate(cna_list):
-            cna['rank'] = i + 1
-        
+            cna["rank"] = i + 1
+
         # Calculate enhanced statistics
         enhanced_stats = self.calculate_enhanced_statistics(cna_list)
-        
+
         # Calculate actual published CVE count (sum of all CNA counts, excludes REJECTED)
-        total_published_cves = sum(cna['count'] for cna in cna_list)
-        
+        total_published_cves = sum(cna["count"] for cna in cna_list)
+
         # Update repo_stats with published count (not raw file count)
-        repo_stats['total_cves'] = total_published_cves
-        
+        repo_stats["total_cves"] = total_published_cves
+
         # Create comprehensive analysis data structure
         comprehensive_data = {
-            'generated_at': datetime.now().isoformat(),
-            'source': 'CVE V5 List (Authoritative)',
-            'repository_stats': repo_stats,
-            'total_cnas': enhanced_stats.get('total_cnas', len(cna_list)),
-            'active_cnas': enhanced_stats.get('active_cnas', 0),
-            'inactive_cnas': enhanced_stats.get('inactive_cnas', 0),
-            'official_cnas': enhanced_stats.get('total_cnas', len(cna_list)),  # All are official in V5 data
-            'unofficial_cnas': 0,  # None are unofficial in V5 data
-            'high_volume_cnas': enhanced_stats.get('high_volume_cnas', 0),
-            'market_concentration': enhanced_stats.get('market_concentration', 0),
-            'median_years_active': enhanced_stats.get('median_years_active', 0),
-            'type_distribution': enhanced_stats.get('type_distribution', []),
-            'cna_list': cna_list,
-            'cna_assigners': cna_list  # For backward compatibility
+            "generated_at": datetime.now().isoformat(),
+            "source": "CVE V5 List (Authoritative)",
+            "repository_stats": repo_stats,
+            "total_cnas": enhanced_stats.get("total_cnas", len(cna_list)),
+            "active_cnas": enhanced_stats.get("active_cnas", 0),
+            "inactive_cnas": enhanced_stats.get("inactive_cnas", 0),
+            "official_cnas": enhanced_stats.get("total_cnas", len(cna_list)),  # All are official in V5 data
+            "unofficial_cnas": 0,  # None are unofficial in V5 data
+            "high_volume_cnas": enhanced_stats.get("high_volume_cnas", 0),
+            "market_concentration": enhanced_stats.get("market_concentration", 0),
+            "median_years_active": enhanced_stats.get("median_years_active", 0),
+            "type_distribution": enhanced_stats.get("type_distribution", []),
+            "cna_list": cna_list,
+            "cna_assigners": cna_list,  # For backward compatibility
         }
-        
+
         # Save comprehensive analysis
-        output_file = self.data_dir / 'cna_analysis.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "cna_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(comprehensive_data, f, indent=2)
-        
+
         logger.info(f"  📄 Generated comprehensive CNA analysis with {len(cna_list)} CNAs")
-        logger.info(f"  📊 Active: {enhanced_stats.get('active_cnas', 0)}, Inactive: {enhanced_stats.get('inactive_cnas', 0)}")
-        
+        logger.info(
+            f"  📊 Active: {enhanced_stats.get('active_cnas', 0)}, Inactive: {enhanced_stats.get('inactive_cnas', 0)}"
+        )
+
         return comprehensive_data
-    
+
     def process_current_year_by_publication_date(self) -> dict[str, dict[str, Any]]:
         """Process CVEs from ALL years, filtering by current year publication date"""
         logger.info(f"    🔍 Scanning all CVE years for {self.current_year} publications...")
-        
-        cves_dir = self.v5_cache_dir / 'cves'
+
+        cves_dir = self.v5_cache_dir / "cves"
         if not cves_dir.exists():
-            logger.error(f"    ❌ CVEs directory not found")
+            logger.error("    ❌ CVEs directory not found")
             return {}
-        
-        cna_stats = defaultdict(lambda: {
-            'count': 0,
-            'cves': [],
-            'first_date': None,
-            'last_date': None,
-            'assigner_org_id': '',
-            'assigner_short_name': '',
-            'severity_counts': defaultdict(int),
-            'cwe_counts': defaultdict(int),
-        })
-        
+
+        cna_stats = defaultdict(
+            lambda: {
+                "count": 0,
+                "cves": [],
+                "first_date": None,
+                "last_date": None,
+                "assigner_org_id": "",
+                "assigner_short_name": "",
+                "severity_counts": defaultdict(int),
+                "cwe_counts": defaultdict(int),
+            }
+        )
+
         total_processed = 0
         current_year_cves = 0
-        
+
         # Scan all year directories
         for year_dir in sorted(cves_dir.iterdir()):
             if not year_dir.is_dir() or not year_dir.name.isdigit():
                 continue
-                
+
             year = int(year_dir.name)
             if not self.quiet:
                 logger.debug(f"    📂 Scanning CVE-{year}-* files for {self.current_year} publications...")
-            
+
             # Get all CVE files in this year directory (handle nested structure)
             cve_files = []
             for subdir in year_dir.iterdir():
                 if subdir.is_dir():
-                    cve_files.extend(subdir.glob('CVE-*.json'))
-            
+                    cve_files.extend(subdir.glob("CVE-*.json"))
+
             year_current_cves = 0
             for cve_file in cve_files:
                 cve_record = self.parse_cve_v5_record(cve_file, include_enrichment=True)
-                if cve_record and cve_record['assigner_org_id']:
+                if cve_record and cve_record["assigner_org_id"]:
                     # Check if this CVE was published in the current year
-                    pub_date = cve_record['publication_date']
+                    pub_date = cve_record["publication_date"]
                     if pub_date:
                         try:
-                            pub_year = datetime.fromisoformat(pub_date.replace('Z', '+00:00')).year
+                            pub_year = datetime.fromisoformat(pub_date.replace("Z", "+00:00")).year
                             if pub_year == self.current_year:
                                 # This CVE was published in current year
-                                org_id = cve_record['assigner_org_id']
-                                
+                                org_id = cve_record["assigner_org_id"]
+
                                 # Update CNA statistics
-                                cna_stats[org_id]['count'] += 1
-                                cna_stats[org_id]['cves'].append(cve_record['cve_id'])
-                                cna_stats[org_id]['assigner_org_id'] = org_id
-                                cna_stats[org_id]['assigner_short_name'] = cve_record['assigner_short_name']
-                                
+                                cna_stats[org_id]["count"] += 1
+                                cna_stats[org_id]["cves"].append(cve_record["cve_id"])
+                                cna_stats[org_id]["assigner_org_id"] = org_id
+                                cna_stats[org_id]["assigner_short_name"] = cve_record["assigner_short_name"]
+
                                 # Track date ranges
-                                if not cna_stats[org_id]['first_date'] or pub_date < cna_stats[org_id]['first_date']:
-                                    cna_stats[org_id]['first_date'] = pub_date
-                                if not cna_stats[org_id]['last_date'] or pub_date > cna_stats[org_id]['last_date']:
-                                    cna_stats[org_id]['last_date'] = pub_date
+                                if not cna_stats[org_id]["first_date"] or pub_date < cna_stats[org_id]["first_date"]:
+                                    cna_stats[org_id]["first_date"] = pub_date
+                                if not cna_stats[org_id]["last_date"] or pub_date > cna_stats[org_id]["last_date"]:
+                                    cna_stats[org_id]["last_date"] = pub_date
 
                                 # CVSS/CWE can be present in either CNA or ADP containers
-                                severity_bucket = cve_record.get('severity_bucket')
+                                severity_bucket = cve_record.get("severity_bucket")
                                 if severity_bucket:
-                                    cna_stats[org_id]['severity_counts'][severity_bucket] += 1
+                                    cna_stats[org_id]["severity_counts"][severity_bucket] += 1
 
-                                for cwe_id in cve_record.get('cwes', []):
-                                    cna_stats[org_id]['cwe_counts'][cwe_id] += 1
-                                
+                                for cwe_id in cve_record.get("cwes", []):
+                                    cna_stats[org_id]["cwe_counts"][cwe_id] += 1
+
                                 year_current_cves += 1
                                 current_year_cves += 1
                         except (ValueError, TypeError):
                             # Skip CVEs with invalid dates
                             pass
-                
+
                 total_processed += 1
                 if total_processed % 5000 == 0 and not self.quiet:
-                    logger.debug(f"    📈 Processed {total_processed} files, found {current_year_cves} {self.current_year} publications...")
-            
+                    logger.debug(
+                        f"    📈 Processed {total_processed} files, found {current_year_cves} {self.current_year} publications..."
+                    )
+
             if year_current_cves > 0 and not self.quiet:
-                logger.debug(f"    ✅ Found {year_current_cves} CVEs published in {self.current_year} from CVE-{year}-* files")
-        
+                logger.debug(
+                    f"    ✅ Found {year_current_cves} CVEs published in {self.current_year} from CVE-{year}-* files"
+                )
+
         if not self.quiet:
-            logger.info(f"    🎯 Total: {current_year_cves} CVEs published in {self.current_year}, from {len(cna_stats)} CNAs")
+            logger.info(
+                f"    🎯 Total: {current_year_cves} CVEs published in {self.current_year}, from {len(cna_stats)} CNAs"
+            )
         return dict(cna_stats)
-    
+
     def generate_current_year_analysis(self) -> dict[str, Any] | None:
         """Generate current year CNA analysis from CVE V5 data based on publication date"""
         logger.info(f"  📅 Generating {self.current_year} CNA analysis from CVE V5 data (by publication date)...")
-        
+
         # Process data from ALL years, filtering by publication date
         current_year_data = self.process_current_year_by_publication_date()
-        
+
         if not current_year_data:
             logger.warning(f"  ⚠️ No CVEs published in {self.current_year} found")
             return None
-        
+
         # Load comprehensive analysis to get full CNA history for years_active calculation
-        logger.info(f"    📊 Loading comprehensive analysis for full CNA history...")
-        comprehensive_file = self.data_dir / 'cna_analysis.json'
+        logger.info("    📊 Loading comprehensive analysis for full CNA history...")
+        comprehensive_file = self.data_dir / "cna_analysis.json"
         comprehensive_cnas = {}
         if comprehensive_file.exists():
             try:
-                with open(comprehensive_file, 'r') as f:
+                with open(comprehensive_file) as f:
                     comprehensive_data = json.load(f)
-                    if 'cna_list' in comprehensive_data:
+                    if "cna_list" in comprehensive_data:
                         # Create lookup by assigner_org_id for quick access
-                        for cna in comprehensive_data['cna_list']:
-                            if 'assigner_org_id' in cna:
-                                comprehensive_cnas[cna['assigner_org_id']] = cna
+                        for cna in comprehensive_data["cna_list"]:
+                            if "assigner_org_id" in cna:
+                                comprehensive_cnas[cna["assigner_org_id"]] = cna
                 logger.info(f"    ✅ Loaded {len(comprehensive_cnas)} CNAs from comprehensive analysis")
             except (FileNotFoundError, json.JSONDecodeError, KeyError, OSError) as e:
                 logger.warning(f"    ⚠️ Could not load comprehensive analysis: {e}")
-        
+
         # Convert to final format
         current_year_cnas = []
         for org_id, stats in current_year_data.items():
             # Classify CNA type
-            cna_types = self.classify_cna_type(org_id, stats['assigner_short_name'])
+            cna_types = self.classify_cna_type(org_id, stats["assigner_short_name"])
             # Use years_active from comprehensive analysis for consistency
             years_active = 1  # Default fallback
             first_cve_year = None
             last_cve_year = None
             if org_id in comprehensive_cnas:
                 comprehensive_cna = comprehensive_cnas[org_id]
-                years_active = comprehensive_cna.get('years_active', 1)
-                first_cve_year = comprehensive_cna.get('first_cve_year')
-                last_cve_year = comprehensive_cna.get('last_cve_year')
+                years_active = comprehensive_cna.get("years_active", 1)
+                first_cve_year = comprehensive_cna.get("first_cve_year")
+                last_cve_year = comprehensive_cna.get("last_cve_year")
             else:
-                if stats['first_date'] and stats['last_date']:
+                if stats["first_date"] and stats["last_date"]:
                     try:
-                        first_cve_year = datetime.fromisoformat(stats['first_date'].replace('Z', '+00:00')).year
-                        last_cve_year = datetime.fromisoformat(stats['last_date'].replace('Z', '+00:00')).year
+                        first_cve_year = datetime.fromisoformat(stats["first_date"].replace("Z", "+00:00")).year
+                        last_cve_year = datetime.fromisoformat(stats["last_date"].replace("Z", "+00:00")).year
                         years_active = max(1, last_cve_year - first_cve_year + 1)
                     except (ValueError, TypeError):
                         years_active = 1
             # Severity/CWE values are pre-aggregated during single-pass file scan
-            severity_counts = stats.get('severity_counts', {})
-            cwe_counts = stats.get('cwe_counts', {})
+            severity_counts = stats.get("severity_counts", {})
+            cwe_counts = stats.get("cwe_counts", {})
             top_cwe_types = dict(sorted(cwe_counts.items(), key=lambda x: x[1], reverse=True)[:5])
             severity_distribution = dict(severity_counts)
-            
+
             # Compute threat intelligence metrics from CVE IDs
             kev_count = 0
             epss_high_count = 0
             epss_elevated_count = 0
-            
-            for cve_id in stats['cves']:
+
+            for cve_id in stats["cves"]:
                 if cve_id in self.kev_cve_set:
                     kev_count += 1
                 if cve_id in self.epss_mapping:
-                    epss_score = self.epss_mapping[cve_id].get('epss_score', 0)
+                    epss_score = self.epss_mapping[cve_id].get("epss_score", 0)
                     if epss_score > 0.5:
                         epss_high_count += 1
                     if epss_score > 0.1:
                         epss_elevated_count += 1
-            
+
             cna_entry = {
-                'name': stats['assigner_short_name'] or org_id,
-                'assigner_org_id': org_id,
-                'count': stats['count'],
-                'rank': 0,  # Will be set after sorting
-                'first_cve_date': stats['first_date'],
-                'last_cve_date': stats['last_date'],
-                'years_active': years_active,  # Use comprehensive value
-                'first_cve_year': first_cve_year,
-                'last_cve_year': last_cve_year,
-                'is_official': True,  # All CVE V5 records are from official CNAs
-                'activity_status': 'Active',  # All current year CNAs are active
-                'cna_types': cna_types,  # Add CNA type classification
-                'severity_distribution': severity_distribution,
-                'top_cwe_types': top_cwe_types,
+                "name": stats["assigner_short_name"] or org_id,
+                "assigner_org_id": org_id,
+                "count": stats["count"],
+                "rank": 0,  # Will be set after sorting
+                "first_cve_date": stats["first_date"],
+                "last_cve_date": stats["last_date"],
+                "years_active": years_active,  # Use comprehensive value
+                "first_cve_year": first_cve_year,
+                "last_cve_year": last_cve_year,
+                "is_official": True,  # All CVE V5 records are from official CNAs
+                "activity_status": "Active",  # All current year CNAs are active
+                "cna_types": cna_types,  # Add CNA type classification
+                "severity_distribution": severity_distribution,
+                "top_cwe_types": top_cwe_types,
                 # Threat intelligence metrics
-                'kev_count': kev_count,
-                'epss_high_count': epss_high_count,
-                'epss_elevated_count': epss_elevated_count,
-                'top_cwes': list(top_cwe_types.items())[:5]
+                "kev_count": kev_count,
+                "epss_high_count": epss_high_count,
+                "epss_elevated_count": epss_elevated_count,
+                "top_cwes": list(top_cwe_types.items())[:5],
             }
             current_year_cnas.append(cna_entry)
-        
+
         # Sort by count and add ranks
-        current_year_cnas.sort(key=lambda x: x['count'], reverse=True)
+        current_year_cnas.sort(key=lambda x: x["count"], reverse=True)
         for i, cna in enumerate(current_year_cnas):
-            cna['rank'] = i + 1
-        
+            cna["rank"] = i + 1
+
         # Create current year data structure
         current_year_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'source': 'CVE V5 List (Authoritative)',
-            'year': self.current_year,
-            'total_cnas': len(current_year_cnas),
-            'active_cnas': len(current_year_cnas),
-            'inactive_cnas': 0,
-            'official_cnas': len(current_year_cnas),  # All are official
-            'unofficial_cnas': 0,  # None are unofficial
-            'cna_list': current_year_cnas,
-            'cna_assigners': current_year_cnas  # For backward compatibility
+            "generated_at": datetime.now().isoformat(),
+            "source": "CVE V5 List (Authoritative)",
+            "year": self.current_year,
+            "total_cnas": len(current_year_cnas),
+            "active_cnas": len(current_year_cnas),
+            "inactive_cnas": 0,
+            "official_cnas": len(current_year_cnas),  # All are official
+            "unofficial_cnas": 0,  # None are unofficial
+            "cna_list": current_year_cnas,
+            "cna_assigners": current_year_cnas,  # For backward compatibility
         }
-        
+
         # Save current year analysis
-        output_file = self.data_dir / 'cna_analysis_current_year.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "cna_analysis_current_year.json"
+        with open(output_file, "w") as f:
             json.dump(current_year_analysis, f, indent=2)
-        
+
         logger.info(f"  📄 Generated {self.current_year} CNA analysis with {len(current_year_cnas)} CNAs")
-        
+
         return current_year_analysis

--- a/data/cve_years.py
+++ b/data/cve_years.py
@@ -43,8 +43,8 @@ except ImportError:
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/cve_years.py
+++ b/data/cve_years.py
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 
 from download_cve_data import CVEDataDownloader
 
+
 # Import optimized utilities if available
 try:
     from data.fast_json import load_json_fast, normalize_severity, parse_iso_date_cached
@@ -106,7 +107,7 @@ class CVEYearsAnalyzer:
         """Initialize downloader and log startup."""
         self.downloader = CVEDataDownloader(quiet=self.quiet)
         if not self.quiet:
-            logger.info(f"📊 CVE Years Analyzer Initialized")
+            logger.info("📊 CVE Years Analyzer Initialized")
             logger.info(f"📅 Target coverage: 1999-{datetime.now().year}")
 
     def extract_severity_info(self, cve_data: dict[str, Any]) -> dict[str, Any]:
@@ -308,7 +309,7 @@ class CVEYearsAnalyzer:
                 if not self.quiet:
                     logger.debug(f"  📊 Loaded {len(self.all_cves_cache)} CVE records (using fast_json)")
             else:
-                with open(self.data_file, "r", encoding="utf-8") as f:
+                with open(self.data_file, encoding="utf-8") as f:
                     self.all_cves_cache = json.load(f)
                 if not self.quiet:
                     logger.debug(f"  📊 Loaded {len(self.all_cves_cache)} CVE records")
@@ -360,7 +361,7 @@ class CVEYearsAnalyzer:
             if not epss_json.exists():
                 epss_json = self.downloader.parse_epss_csv()
             if epss_json and Path(epss_json).exists():
-                with open(epss_json, "r", encoding="utf-8") as ef:
+                with open(epss_json, encoding="utf-8") as ef:
                     self.epss_mapping = json.load(ef)
             else:
                 self.epss_mapping = {}
@@ -373,7 +374,7 @@ class CVEYearsAnalyzer:
             if not kev_json.exists():
                 kev_json = self.downloader.parse_kev_json()
             if kev_json and Path(kev_json).exists():
-                with open(kev_json, "r", encoding="utf-8") as kf:
+                with open(kev_json, encoding="utf-8") as kf:
                     raw = json.load(kf)
                     self.kev_mapping = {k: bool(v) for k, v in raw.items()}
             else:
@@ -809,7 +810,7 @@ class CVEYearsAnalyzer:
         if self.data_file is None:
             return {}
 
-        with open(self.data_file, "r", encoding="utf-8") as f:
+        with open(self.data_file, encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line:

--- a/data/cvss_analysis.py
+++ b/data/cvss_analysis.py
@@ -15,8 +15,8 @@ from typing import Any
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 
@@ -43,7 +43,7 @@ class CVSSAnalyzer:
             logger.info("  📊 Generating CVSS analysis...")
 
         # Initialize combined CVSS data structure for available versions
-        combined_cvss = {
+        combined_cvss: dict[str, dict[str, dict[str, Any]]] = {
             "v2.0": {"severity": {}, "scores": {}},
             "v3.0": {"severity": {}, "scores": {}},
             "v3.1": {"severity": {}, "scores": {}},
@@ -129,7 +129,7 @@ class CVSSAnalyzer:
             kev_global_count += kev_count
 
         # Create binned score distributions (0-0.99, 1-1.99, etc.)
-        binned_scores = {}
+        binned_scores: dict[str, dict[str, int]] = {}
         for version in ["v2.0", "v3.0", "v3.1", "v4.0"]:
             binned_scores[version] = {}
 
@@ -203,7 +203,7 @@ class CVSSAnalyzer:
             return {}
 
         # Create binned score distributions for current year
-        binned_scores = {}
+        binned_scores: dict[str, dict[str, int]] = {}
         total_cves_with_cvss = 0
 
         for version in ["v2.0", "v3.0", "v3.1", "v4.0"]:

--- a/data/cvss_analysis.py
+++ b/data/cvss_analysis.py
@@ -79,7 +79,7 @@ class CVSSAnalyzer:
                     temporal_data[year] = {"v2.0": 0, "v3.0": 0, "v3.1": 0, "v4.0": 0}
 
                 # Process each CVSS version that exists in the data
-                for version in cvss_data.keys():
+                for version in cvss_data:
                     if version in combined_cvss:  # Only process known versions
                         version_data = cvss_data[version]
 

--- a/data/cvss_analysis.py
+++ b/data/cvss_analysis.py
@@ -3,6 +3,7 @@
 CVSS Analysis Module
 Handles all CVSS (Common Vulnerability Scoring System) related data processing and analysis
 """
+
 from __future__ import annotations
 
 import json
@@ -10,6 +11,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
 
 try:
     from data.logging_config import get_logger
@@ -22,90 +24,86 @@ logger = get_logger(__name__)
 @dataclass
 class CVSSAnalyzer:
     """Handles CVSS-specific analysis and data processing"""
+
     base_dir: Path
     cache_dir: Path
     data_dir: Path
     quiet: bool = False
     current_year: int = field(default_factory=lambda: datetime.now().year)
-    
+
     def __post_init__(self) -> None:
         """Convert path arguments to Path objects if needed."""
         self.base_dir = Path(self.base_dir)
         self.cache_dir = Path(self.cache_dir)
         self.data_dir = Path(self.data_dir)
-    
+
     def generate_cvss_analysis(self, all_year_data: list[dict[str, Any]]) -> dict[str, Any]:
         """Generate comprehensive CVSS analysis from all years data"""
         if not self.quiet:
             logger.info("  📊 Generating CVSS analysis...")
-        
+
         # Initialize combined CVSS data structure for available versions
         combined_cvss = {
-            'v2.0': {'severity': {}, 'scores': {}},
-            'v3.0': {'severity': {}, 'scores': {}},
-            'v3.1': {'severity': {}, 'scores': {}},
-            'v4.0': {'severity': {}, 'scores': {}}
+            "v2.0": {"severity": {}, "scores": {}},
+            "v3.0": {"severity": {}, "scores": {}},
+            "v3.1": {"severity": {}, "scores": {}},
+            "v4.0": {"severity": {}, "scores": {}},
         }
-        
+
         # Initialize temporal data for line chart
         temporal_data = {}
 
         # EPSS-aware aggregates (summary only, no per-CVE payloads)
         epss_global_buckets = {
-            'epss_gt_0_1': 0,
-            'epss_gt_0_5': 0,
-            'epss_gt_0_9': 0,
+            "epss_gt_0_1": 0,
+            "epss_gt_0_5": 0,
+            "epss_gt_0_9": 0,
         }
         epss_by_year = {}
 
         # CISA KEV aggregates (summary only)
         kev_global_count = 0
         kev_by_year = {}
-        
+
         total_cves_with_cvss = 0
-        
+
         # Aggregate data from all years
         for year_data in all_year_data:
-            year = year_data.get('year', 'Unknown')
-            
-            if 'cvss' in year_data:
-                cvss_data = year_data['cvss']
-                
+            year = year_data.get("year", "Unknown")
+
+            if "cvss" in year_data:
+                cvss_data = year_data["cvss"]
+
                 # Initialize temporal data for this year
                 if year not in temporal_data:
-                    temporal_data[year] = {
-                        'v2.0': 0,
-                        'v3.0': 0,
-                        'v3.1': 0,
-                        'v4.0': 0
-                    }
-                
+                    temporal_data[year] = {"v2.0": 0, "v3.0": 0, "v3.1": 0, "v4.0": 0}
+
                 # Process each CVSS version that exists in the data
                 for version in cvss_data.keys():
                     if version in combined_cvss:  # Only process known versions
                         version_data = cvss_data[version]
-                        
+
                         # Add to temporal data (count of CVEs with this version)
-                        if 'total' in version_data:
-                            temporal_data[year][version] = version_data['total']
-                        
+                        if "total" in version_data:
+                            temporal_data[year][version] = version_data["total"]
+
                         # Add to total CVEs with CVSS (use total field from version data)
-                        if 'total' in version_data:
-                            total_cves_with_cvss += version_data['total']
-                        
+                        if "total" in version_data:
+                            total_cves_with_cvss += version_data["total"]
+
                         # Aggregate severity distributions (use correct field name)
-                        if 'severity_distribution' in version_data:
-                            for severity, count in version_data['severity_distribution'].items():
-                                if severity not in combined_cvss[version]['severity']:
-                                    combined_cvss[version]['severity'][severity] = 0
-                                combined_cvss[version]['severity'][severity] += count
-                        
+                        if "severity_distribution" in version_data:
+                            for severity, count in version_data["severity_distribution"].items():
+                                if severity not in combined_cvss[version]["severity"]:
+                                    combined_cvss[version]["severity"][severity] = 0
+                                combined_cvss[version]["severity"][severity] += count
+
                         # Aggregate score distributions (use correct field name)
-                        if 'score_distribution' in version_data:
-                            for score, count in version_data['score_distribution'].items():
-                                if score not in combined_cvss[version]['scores']:
-                                    combined_cvss[version]['scores'][score] = 0
-                                combined_cvss[version]['scores'][score] += count
+                        if "score_distribution" in version_data:
+                            for score, count in version_data["score_distribution"].items():
+                                if score not in combined_cvss[version]["scores"]:
+                                    combined_cvss[version]["scores"][score] = 0
+                                combined_cvss[version]["scores"][score] += count
 
                 # EPSS-aware metrics, if present at year summary level
                 # Expected optional structure on year_data['cvss']:
@@ -114,35 +112,35 @@ class CVSSAnalyzer:
                 #       'epss_gt_0_5': int,
                 #       'epss_gt_0_9': int
                 #   }
-                if epss_summary := cvss_data.get('epss_summary'):
+                if epss_summary := cvss_data.get("epss_summary"):
                     year_epss = {
-                        'epss_gt_0_1': int(epss_summary.get('epss_gt_0_1', 0)),
-                        'epss_gt_0_5': int(epss_summary.get('epss_gt_0_5', 0)),
-                        'epss_gt_0_9': int(epss_summary.get('epss_gt_0_9', 0)),
+                        "epss_gt_0_1": int(epss_summary.get("epss_gt_0_1", 0)),
+                        "epss_gt_0_5": int(epss_summary.get("epss_gt_0_5", 0)),
+                        "epss_gt_0_9": int(epss_summary.get("epss_gt_0_9", 0)),
                     }
                     epss_by_year[year] = year_epss
                     for k, v in year_epss.items():
                         epss_global_buckets[k] += v
 
             # KEV-aware metrics, if present at year level
-            kev_info = year_data.get('kev') or {}
-            kev_count = int(kev_info.get('kev_count', 0))
+            kev_info = year_data.get("kev") or {}
+            kev_count = int(kev_info.get("kev_count", 0))
             kev_by_year[year] = kev_count
             kev_global_count += kev_count
-        
+
         # Create binned score distributions (0-0.99, 1-1.99, etc.)
         binned_scores = {}
-        for version in ['v2.0', 'v3.0', 'v3.1', 'v4.0']:
+        for version in ["v2.0", "v3.0", "v3.1", "v4.0"]:
             binned_scores[version] = {}
-            
+
             # Initialize bins
             for i in range(10):
                 bin_key = f"{i}-{i}.99"
                 binned_scores[version][bin_key] = 0
             binned_scores[version]["10.0"] = 0  # Special case for perfect 10.0
-            
+
             # Aggregate scores into bins
-            for score_str, count in combined_cvss[version]['scores'].items():
+            for score_str, count in combined_cvss[version]["scores"].items():
                 try:
                     score = float(score_str)
                     if score == 10.0:
@@ -154,76 +152,76 @@ class CVSSAnalyzer:
                             binned_scores[version][bin_key] += count
                 except (ValueError, KeyError):
                     continue
-        
+
         # Remove empty bins
         for version in binned_scores:
             binned_scores[version] = {k: v for k, v in binned_scores[version].items() if v > 0}
-        
+
         # Calculate overall statistics
         total_by_version = {}
-        for version in ['v2.0', 'v3.0', 'v3.1', 'v4.0']:
-            total_by_version[version] = sum(combined_cvss[version]['severity'].values())
-        
+        for version in ["v2.0", "v3.0", "v3.1", "v4.0"]:
+            total_by_version[version] = sum(combined_cvss[version]["severity"].values())
+
         # Sort temporal data by year for consistent ordering
         sorted_temporal_data = dict(sorted(temporal_data.items()))
-        
+
         cvss_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'total_cves_with_cvss': total_cves_with_cvss,
-            'total_by_version': total_by_version,
-            'severity_distribution': {version: data['severity'] for version, data in combined_cvss.items()},
-            'score_distribution': {version: data['scores'] for version, data in combined_cvss.items()},
-            'binned_score_distribution': binned_scores,
-            'temporal_data': sorted_temporal_data,
+            "generated_at": datetime.now().isoformat(),
+            "total_cves_with_cvss": total_cves_with_cvss,
+            "total_by_version": total_by_version,
+            "severity_distribution": {version: data["severity"] for version, data in combined_cvss.items()},
+            "score_distribution": {version: data["scores"] for version, data in combined_cvss.items()},
+            "binned_score_distribution": binned_scores,
+            "temporal_data": sorted_temporal_data,
             # EPSS-only aggregate metrics for risk-focused visualizations
-            'epss_global_buckets': epss_global_buckets,
-            'epss_by_year': epss_by_year,
+            "epss_global_buckets": epss_global_buckets,
+            "epss_by_year": epss_by_year,
             # KEV aggregate metrics
-            'kev_global_count': kev_global_count,
-            'kev_by_year': kev_by_year,
+            "kev_global_count": kev_global_count,
+            "kev_by_year": kev_by_year,
         }
-        
+
         # Save to file
-        output_file = self.data_dir / 'cvss_analysis.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "cvss_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(cvss_analysis, f, indent=2)
-        
+
         if not self.quiet:
             logger.info(f"  ✅ Generated CVSS analysis with {total_cves_with_cvss:,} CVEs across all versions")
         return cvss_analysis
-    
+
     def generate_current_year_cvss_analysis(self, current_year_data: dict[str, Any]) -> dict[str, Any]:
         """Generate current year CVSS analysis"""
         if not self.quiet:
-            logger.info(f"    📊 Generating current year CVSS analysis...")
-        
+            logger.info("    📊 Generating current year CVSS analysis...")
+
         # Extract CVSS data from current year
-        cvss_data = current_year_data.get('cvss', {})
-        
+        cvss_data = current_year_data.get("cvss", {})
+
         if not cvss_data:
             logger.warning(f"    ⚠️  No CVSS data found for {self.current_year}")
             return {}
-        
+
         # Create binned score distributions for current year
         binned_scores = {}
         total_cves_with_cvss = 0
-        
-        for version in ['v2.0', 'v3.0', 'v3.1', 'v4.0']:
-            if version in cvss_data and 'score_distribution' in cvss_data[version]:
+
+        for version in ["v2.0", "v3.0", "v3.1", "v4.0"]:
+            if version in cvss_data and "score_distribution" in cvss_data[version]:
                 binned_scores[version] = {}
-                
+
                 # Add to total CVEs with CVSS
-                if 'total' in cvss_data[version]:
-                    total_cves_with_cvss += cvss_data[version]['total']
-                
+                if "total" in cvss_data[version]:
+                    total_cves_with_cvss += cvss_data[version]["total"]
+
                 # Initialize bins
                 for i in range(10):
                     bin_key = f"{i}-{i}.99"
                     binned_scores[version][bin_key] = 0
                 binned_scores[version]["10.0"] = 0
-                
+
                 # Aggregate scores into bins
-                for score_str, count in cvss_data[version]['score_distribution'].items():
+                for score_str, count in cvss_data[version]["score_distribution"].items():
                     try:
                         score = float(score_str)
                         if score == 10.0:
@@ -235,33 +233,39 @@ class CVSSAnalyzer:
                                 binned_scores[version][bin_key] += count
                     except (ValueError, KeyError):
                         continue
-                
+
                 # Remove empty bins
                 binned_scores[version] = {k: v for k, v in binned_scores[version].items() if v > 0}
-        
+
         # Calculate totals by version
         total_by_version = {}
-        for version in ['v2.0', 'v3.0', 'v3.1', 'v4.0']:
-            if version in cvss_data and 'severity_distribution' in cvss_data[version]:
-                total_by_version[version] = sum(cvss_data[version]['severity_distribution'].values())
+        for version in ["v2.0", "v3.0", "v3.1", "v4.0"]:
+            if version in cvss_data and "severity_distribution" in cvss_data[version]:
+                total_by_version[version] = sum(cvss_data[version]["severity_distribution"].values())
             else:
                 total_by_version[version] = 0
-        
+
         current_year_cvss_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'year': self.current_year,
-            'total_cves_with_cvss': total_cves_with_cvss,
-            'total_by_version': total_by_version,
-            'severity_distribution': {version: cvss_data.get(version, {}).get('severity_distribution', {}) for version in ['v2.0', 'v3.0', 'v3.1', 'v4.0']},
-            'score_distribution': {version: cvss_data.get(version, {}).get('score_distribution', {}) for version in ['v2.0', 'v3.0', 'v3.1', 'v4.0']},
-            'binned_score_distribution': binned_scores
+            "generated_at": datetime.now().isoformat(),
+            "year": self.current_year,
+            "total_cves_with_cvss": total_cves_with_cvss,
+            "total_by_version": total_by_version,
+            "severity_distribution": {
+                version: cvss_data.get(version, {}).get("severity_distribution", {})
+                for version in ["v2.0", "v3.0", "v3.1", "v4.0"]
+            },
+            "score_distribution": {
+                version: cvss_data.get(version, {}).get("score_distribution", {})
+                for version in ["v2.0", "v3.0", "v3.1", "v4.0"]
+            },
+            "binned_score_distribution": binned_scores,
         }
-        
+
         # Save current year analysis
-        current_year_file = self.data_dir / 'cvss_analysis_current_year.json'
-        with open(current_year_file, 'w') as f:
+        current_year_file = self.data_dir / "cvss_analysis_current_year.json"
+        with open(current_year_file, "w") as f:
             json.dump(current_year_cvss_analysis, f, indent=2)
-        
+
         if not self.quiet:
-            logger.info(f"    ✅ Generated current year CVSS analysis")
+            logger.info("    ✅ Generated current year CVSS analysis")
         return current_year_cvss_analysis

--- a/data/cwe_analysis.py
+++ b/data/cwe_analysis.py
@@ -3,6 +3,7 @@
 CWE Analysis Module
 Handles all CWE (Common Weakness Enumeration) related data processing and analysis
 """
+
 from __future__ import annotations
 
 import json
@@ -10,6 +11,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+
 
 try:
     from data.logging_config import get_logger
@@ -22,172 +24,173 @@ logger = get_logger(__name__)
 @dataclass
 class CWEAnalyzer:
     """Handles CWE-specific analysis and data processing"""
+
     base_dir: Path
     cache_dir: Path
     data_dir: Path
     quiet: bool = False
     current_year: int = field(default_factory=lambda: datetime.now().year)
-    
+
     def __post_init__(self) -> None:
         """Convert path arguments to Path objects if needed."""
         self.base_dir = Path(self.base_dir)
         self.cache_dir = Path(self.cache_dir)
         self.data_dir = Path(self.data_dir)
-    
+
     def generate_cwe_analysis(self, all_year_data: list[dict[str, Any]]) -> dict[str, Any]:
         """Generate CWE analysis across all years"""
         if not self.quiet:
-            logger.info(f"  🔍 Generating CWE analysis...")
-        
+            logger.info("  🔍 Generating CWE analysis...")
+
         # Aggregate CWE data from all years
         combined_cwe = {}
-        
+
         for year_data in all_year_data:
-            if 'cwe' in year_data and 'top_cwes' in year_data['cwe']:
+            if "cwe" in year_data and "top_cwes" in year_data["cwe"]:
                 # Aggregate CWE counts
-                for cwe_entry in year_data['cwe']['top_cwes']:
-                    cwe_full = cwe_entry['cwe']  # e.g., "CWE-79"
-                    cwe_id = cwe_full.replace('CWE-', '') if cwe_full.startswith('CWE-') else cwe_full
-                    count = cwe_entry['count']
-                    
+                for cwe_entry in year_data["cwe"]["top_cwes"]:
+                    cwe_full = cwe_entry["cwe"]  # e.g., "CWE-79"
+                    cwe_id = cwe_full.replace("CWE-", "") if cwe_full.startswith("CWE-") else cwe_full
+                    count = cwe_entry["count"]
+
                     if cwe_id not in combined_cwe:
                         combined_cwe[cwe_id] = {
-                            'id': cwe_id,
-                            'name': cwe_entry.get('name', f'CWE-{cwe_id}'),
-                            'count': 0
+                            "id": cwe_id,
+                            "name": cwe_entry.get("name", f"CWE-{cwe_id}"),
+                            "count": 0,
                         }
-                    
-                    combined_cwe[cwe_id]['count'] += count
-        
+
+                    combined_cwe[cwe_id]["count"] += count
+
         # Sort by count and get top CWEs
-        top_cwes = sorted(combined_cwe.values(), key=lambda x: x['count'], reverse=True)
-        
+        top_cwes = sorted(combined_cwe.values(), key=lambda x: x["count"], reverse=True)
+
         # Calculate total CVEs with CWE from aggregated counts
-        total_cves_with_cwe = sum(cwe['count'] for cwe in combined_cwe.values())
-        
+        total_cves_with_cwe = sum(cwe["count"] for cwe in combined_cwe.values())
+
         # Add common CWE descriptions for better understanding
         cwe_descriptions = {
-            '79': 'Cross-site Scripting (XSS)',
-            '89': 'SQL Injection',
-            '20': 'Improper Input Validation',
-            '22': 'Path Traversal',
-            '352': 'Cross-Site Request Forgery (CSRF)',
-            '78': 'OS Command Injection',
-            '190': 'Integer Overflow',
-            '476': 'NULL Pointer Dereference',
-            '94': 'Code Injection',
-            '119': 'Buffer Overflow',
-            '125': 'Out-of-bounds Read',
-            '787': 'Out-of-bounds Write',
-            '416': 'Use After Free',
-            '200': 'Information Exposure',
-            '434': 'Unrestricted Upload of File',
-            '862': 'Missing Authorization',
-            '863': 'Incorrect Authorization',
-            '269': 'Improper Privilege Management',
-            '287': 'Improper Authentication',
-            '295': 'Improper Certificate Validation'
+            "79": "Cross-site Scripting (XSS)",
+            "89": "SQL Injection",
+            "20": "Improper Input Validation",
+            "22": "Path Traversal",
+            "352": "Cross-Site Request Forgery (CSRF)",
+            "78": "OS Command Injection",
+            "190": "Integer Overflow",
+            "476": "NULL Pointer Dereference",
+            "94": "Code Injection",
+            "119": "Buffer Overflow",
+            "125": "Out-of-bounds Read",
+            "787": "Out-of-bounds Write",
+            "416": "Use After Free",
+            "200": "Information Exposure",
+            "434": "Unrestricted Upload of File",
+            "862": "Missing Authorization",
+            "863": "Incorrect Authorization",
+            "269": "Improper Privilege Management",
+            "287": "Improper Authentication",
+            "295": "Improper Certificate Validation",
         }
-        
+
         # Enhance CWE entries with descriptions
         for cwe in top_cwes:
-            cwe_id = cwe['id']
+            cwe_id = cwe["id"]
             if cwe_id in cwe_descriptions:
-                cwe['description'] = cwe_descriptions[cwe_id]
-                cwe['name'] = f"CWE-{cwe_id}: {cwe_descriptions[cwe_id]}"
+                cwe["description"] = cwe_descriptions[cwe_id]
+                cwe["name"] = f"CWE-{cwe_id}: {cwe_descriptions[cwe_id]}"
             else:
-                cwe['description'] = f"CWE-{cwe_id}"
-        
+                cwe["description"] = f"CWE-{cwe_id}"
+
         cwe_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'total_cves_with_cwe': total_cves_with_cwe,
-            'total_unique_cwes': len(combined_cwe),
-            'top_cwes': top_cwes,  # All CWEs
-            'top_cwes_limited': top_cwes[:20]  # Top 20 for charts
+            "generated_at": datetime.now().isoformat(),
+            "total_cves_with_cwe": total_cves_with_cwe,
+            "total_unique_cwes": len(combined_cwe),
+            "top_cwes": top_cwes,  # All CWEs
+            "top_cwes_limited": top_cwes[:20],  # Top 20 for charts
         }
-        
+
         # Save to file
-        output_file = self.data_dir / 'cwe_analysis.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "cwe_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(cwe_analysis, f, indent=2)
-        
+
         if not self.quiet:
             logger.info(f"  ✅ Generated CWE analysis with {len(combined_cwe):,} unique CWEs")
         return cwe_analysis
-    
+
     def generate_current_year_cwe_analysis(self, current_year_data: dict[str, Any]) -> dict[str, Any]:
         """Generate current year CWE analysis"""
         if not self.quiet:
-            logger.info(f"    🔍 Generating current year CWE analysis...")
-        
+            logger.info("    🔍 Generating current year CWE analysis...")
+
         # Extract CWE data from current year
-        cwe_data = current_year_data.get('cwe', {})
-        
-        if not cwe_data or 'top_cwes' not in cwe_data:
+        cwe_data = current_year_data.get("cwe", {})
+
+        if not cwe_data or "top_cwes" not in cwe_data:
             logger.warning(f"    ⚠️  No CWE data found for {self.current_year}")
             return {}
-        
+
         # Get current year CWEs
-        current_year_cwes = cwe_data['top_cwes']
-        
+        current_year_cwes = cwe_data["top_cwes"]
+
         # Add descriptions to current year CWEs
         cwe_descriptions = {
-            '79': 'Cross-site Scripting (XSS)',
-            '89': 'SQL Injection',
-            '20': 'Improper Input Validation',
-            '22': 'Path Traversal',
-            '352': 'Cross-Site Request Forgery (CSRF)',
-            '78': 'OS Command Injection',
-            '190': 'Integer Overflow',
-            '476': 'NULL Pointer Dereference',
-            '94': 'Code Injection',
-            '119': 'Buffer Overflow',
-            '125': 'Out-of-bounds Read',
-            '787': 'Out-of-bounds Write',
-            '416': 'Use After Free',
-            '200': 'Information Exposure',
-            '434': 'Unrestricted Upload of File',
-            '862': 'Missing Authorization',
-            '863': 'Incorrect Authorization',
-            '269': 'Improper Privilege Management',
-            '287': 'Improper Authentication',
-            '295': 'Improper Certificate Validation'
+            "79": "Cross-site Scripting (XSS)",
+            "89": "SQL Injection",
+            "20": "Improper Input Validation",
+            "22": "Path Traversal",
+            "352": "Cross-Site Request Forgery (CSRF)",
+            "78": "OS Command Injection",
+            "190": "Integer Overflow",
+            "476": "NULL Pointer Dereference",
+            "94": "Code Injection",
+            "119": "Buffer Overflow",
+            "125": "Out-of-bounds Read",
+            "787": "Out-of-bounds Write",
+            "416": "Use After Free",
+            "200": "Information Exposure",
+            "434": "Unrestricted Upload of File",
+            "862": "Missing Authorization",
+            "863": "Incorrect Authorization",
+            "269": "Improper Privilege Management",
+            "287": "Improper Authentication",
+            "295": "Improper Certificate Validation",
         }
-        
+
         # Enhance CWE entries with descriptions
         enhanced_cwes = []
         for cwe in current_year_cwes:
-            cwe_full = cwe['cwe']  # e.g., "CWE-79"
-            cwe_id = cwe_full.replace('CWE-', '') if cwe_full.startswith('CWE-') else cwe_full
+            cwe_full = cwe["cwe"]  # e.g., "CWE-79"
+            cwe_id = cwe_full.replace("CWE-", "") if cwe_full.startswith("CWE-") else cwe_full
             enhanced_cwe = cwe.copy()
-            enhanced_cwe['id'] = cwe_id  # Add id field for consistency
-            
+            enhanced_cwe["id"] = cwe_id  # Add id field for consistency
+
             if cwe_id in cwe_descriptions:
-                enhanced_cwe['description'] = cwe_descriptions[cwe_id]
-                enhanced_cwe['name'] = f"CWE-{cwe_id}: {cwe_descriptions[cwe_id]}"
+                enhanced_cwe["description"] = cwe_descriptions[cwe_id]
+                enhanced_cwe["name"] = f"CWE-{cwe_id}: {cwe_descriptions[cwe_id]}"
             else:
-                enhanced_cwe['description'] = f"CWE-{cwe_id}"
-                enhanced_cwe['name'] = f"CWE-{cwe_id}"
-            
+                enhanced_cwe["description"] = f"CWE-{cwe_id}"
+                enhanced_cwe["name"] = f"CWE-{cwe_id}"
+
             enhanced_cwes.append(enhanced_cwe)
-        
+
         # Calculate total CVEs with CWE from individual counts
-        total_cves_with_cwe = sum(cwe['count'] for cwe in current_year_cwes)
-        
+        total_cves_with_cwe = sum(cwe["count"] for cwe in current_year_cwes)
+
         current_year_cwe_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'year': self.current_year,
-            'total_cves_with_cwe': total_cves_with_cwe,
-            'total_unique_cwes': len(current_year_cwes),
-            'top_cwes': enhanced_cwes,  # All CWEs
-            'top_cwes_limited': enhanced_cwes[:20]  # Top 20 for charts
+            "generated_at": datetime.now().isoformat(),
+            "year": self.current_year,
+            "total_cves_with_cwe": total_cves_with_cwe,
+            "total_unique_cwes": len(current_year_cwes),
+            "top_cwes": enhanced_cwes,  # All CWEs
+            "top_cwes_limited": enhanced_cwes[:20],  # Top 20 for charts
         }
-        
+
         # Save current year analysis
-        current_year_file = self.data_dir / 'cwe_analysis_current_year.json'
-        with open(current_year_file, 'w') as f:
+        current_year_file = self.data_dir / "cwe_analysis_current_year.json"
+        with open(current_year_file, "w") as f:
             json.dump(current_year_cwe_analysis, f, indent=2)
-        
+
         if not self.quiet:
             logger.info(f"    ✅ Generated current year CWE analysis with {len(current_year_cwes)} CWEs")
         return current_year_cwe_analysis

--- a/data/cwe_analysis.py
+++ b/data/cwe_analysis.py
@@ -15,8 +15,8 @@ from typing import Any
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/download_cve_data.py
+++ b/data/download_cve_data.py
@@ -4,6 +4,7 @@ CVE Data Download Script
 Downloads and caches CVE data from NVD source for processing
 Replaces the wget step from GitHub Actions with proper Python error handling
 """
+
 from __future__ import annotations
 
 import csv
@@ -15,15 +16,15 @@ from pathlib import Path
 from typing import Any
 
 import requests
-
 from protocols import (
-    HttpClient,
     DataReader,
     DataWriter,
     FileSystemDataReader,
     FileSystemDataWriter,
+    HttpClient,
     RequestsHttpClient,
 )
+
 
 try:
     from data.logging_config import get_logger
@@ -32,18 +33,19 @@ except ImportError:
 
 logger = get_logger(__name__)
 
+
 class CVEDataDownloader:
     """Downloads and manages CVE data from NVD source.
-    
+
     Supports dependency injection for testability:
     - http_client: HttpClient protocol for HTTP requests
     - data_reader: DataReader protocol for file reading
     - data_writer: DataWriter protocol for file writing
-    
+
     When dependencies are not provided, uses default implementations
     (requests for HTTP, filesystem for files).
     """
-    
+
     def __init__(
         self,
         cache_dir: Path | str | None = None,
@@ -55,16 +57,16 @@ class CVEDataDownloader:
     ) -> None:
         self.quiet: bool = quiet
         self.base_dir: Path = Path(__file__).parent
-        self.cache_dir: Path = Path(cache_dir) if cache_dir else (self.base_dir / 'cache')
-        
+        self.cache_dir: Path = Path(cache_dir) if cache_dir else (self.base_dir / "cache")
+
         # Dependency injection with defaults
         self._http_client = http_client or RequestsHttpClient()
         self._data_reader = data_reader or FileSystemDataReader()
         self._data_writer = data_writer or FileSystemDataWriter()
-        
+
         # Create cache directory using writer
         self._data_writer.mkdir(self.cache_dir)
-        
+
         # Data source configuration
         self.nvd_url: str = "https://nvd.handsonhacking.org/nvd.json"
         self.cache_file: Path = self.cache_dir / "nvd.json"
@@ -87,9 +89,11 @@ class CVEDataDownloader:
         # is unknown and the threshold is deliberately loose. Tighten it once
         # there is a distribution to set it from, rather than from one sample.
         self.min_completeness_ratio: float = 0.995
-        
+
         # CNA mapping files for proper name resolution
-        self.cna_list_url: str = "https://raw.githubusercontent.com/CVEProject/cve-website/dev/src/assets/data/CNAsList.json"
+        self.cna_list_url: str = (
+            "https://raw.githubusercontent.com/CVEProject/cve-website/dev/src/assets/data/CNAsList.json"
+        )
         self.cna_name_map_url: str = "https://www.cve.org/cve-partner-name-map.json"
         self.cna_list_file: Path = self.cache_dir / "cna_list.json"
         self.cna_name_map_file: Path = self.cache_dir / "cna_name_map.json"
@@ -112,16 +116,16 @@ class CVEDataDownloader:
             logger.info("🔽 CVE Data Downloader Initialized")
             logger.info(f"📁 Cache directory: {self.cache_dir}")
             logger.info(f"🌐 Data source: {self.nvd_url}")
-    
+
     def is_cache_valid(self) -> bool:
         """Check if cached data is still valid"""
         if not self._data_reader.exists(self.cache_file) or not self._data_reader.exists(self.cache_info_file):
             return False
-        
+
         try:
             cache_info = self._data_reader.read_json(self.cache_info_file)
-            
-            cache_time = datetime.fromisoformat(cache_info['download_time'])
+
+            cache_time = datetime.fromisoformat(cache_info["download_time"])
             # Older cache_info files carry a naive local timestamp; treat those
             # as UTC so the comparison below stays valid across the format change.
             if cache_time.tzinfo is None:
@@ -130,16 +134,16 @@ class CVEDataDownloader:
                 if not self.quiet:
                     logger.info(f"⏰ Cache expired (older than {self.cache_duration})")
                 return False
-            
+
             if not self.quiet:
                 logger.info(f"✅ Cache is valid (downloaded {cache_time.strftime('%Y-%m-%d %H:%M:%S')})")
             return True
-            
+
         except (json.JSONDecodeError, KeyError, ValueError) as e:
             if not self.quiet:
                 logger.warning(f"⚠️  Cache info corrupted: {e}")
             return False
-    
+
     def download_data(self, force: bool = False, manifest: dict[str, Any] | None = None) -> Path:
         """Download CVE data from NVD source.
 
@@ -153,32 +157,34 @@ class CVEDataDownloader:
             if not self.quiet:
                 logger.info("📋 Using cached data")
             return self.cache_file
-        
+
         if not self.quiet:
             logger.info(f"🔽 Downloading CVE data from {self.nvd_url}")
-        
+
         try:
             # Start download with progress tracking (use injected HTTP client)
             response = self._http_client.get(self.nvd_url, stream=True)
             response.raise_for_status()
-            
+
             # Get file size for progress tracking
-            total_size = int(response.headers.get('content-length', 0))
+            total_size = int(response.headers.get("content-length", 0))
             downloaded_size = 0
-            
+
             # Download with progress updates - collect chunks then write
             chunks: list[bytes] = []
             for chunk in response.iter_content(chunk_size=8192):
                 if chunk:
                     chunks.append(chunk)
                     downloaded_size += len(chunk)
-                    
+
                     # Show progress every 10MB
                     if downloaded_size % (10 * 1024 * 1024) == 0 or downloaded_size == total_size:
                         if total_size > 0:
                             progress = (downloaded_size / total_size) * 100
-                            logger.debug(f"  📥 Downloaded {downloaded_size // (1024*1024)}MB / {total_size // (1024*1024)}MB ({progress:.1f}%)")
-            
+                            logger.debug(
+                                f"  📥 Downloaded {downloaded_size // (1024 * 1024)}MB / {total_size // (1024 * 1024)}MB ({progress:.1f}%)"
+                            )
+
             # A dropped connection previously produced a short file that was
             # written and reported as a success. content-length is advisory,
             # but when the server sends one, a mismatch means truncation.
@@ -189,36 +195,36 @@ class CVEDataDownloader:
                 )
 
             # Write using data writer
-            self._data_writer.write_bytes(self.cache_file, b''.join(chunks))
-            
+            self._data_writer.write_bytes(self.cache_file, b"".join(chunks))
+
             # Verify the object against the producer's manifest before we
             # treat it as usable. Raises on any mismatch.
             self.verify_download_against_manifest(manifest, downloaded_size)
 
             # Calculate file hash for integrity check
             file_hash = self.calculate_file_hash_streaming(self.cache_file)
-            
+
             # Save cache info using data writer
             cache_info = {
                 # UTC: this value is compared against build time to derive data
                 # age, and a naive local timestamp made that comparison wrong.
-                'download_time': datetime.now(UTC).isoformat(),
-                'file_size': downloaded_size,
-                'file_hash': file_hash,
-                'source_url': self.nvd_url,
-                'source_last_run': (manifest or {}).get('last_run_iso'),
-                'source_cve_count': (manifest or {}).get('cve_count'),
-                'source_commit_sha': (manifest or {}).get('commit_sha'),
+                "download_time": datetime.now(UTC).isoformat(),
+                "file_size": downloaded_size,
+                "file_hash": file_hash,
+                "source_url": self.nvd_url,
+                "source_last_run": (manifest or {}).get("last_run_iso"),
+                "source_cve_count": (manifest or {}).get("cve_count"),
+                "source_commit_sha": (manifest or {}).get("commit_sha"),
             }
-            
+
             self._data_writer.write_json(self.cache_info_file, cache_info)
-            
+
             logger.info("✅ Download completed successfully")
-            logger.info(f"📊 File size: {downloaded_size // (1024*1024)}MB")
+            logger.info(f"📊 File size: {downloaded_size // (1024 * 1024)}MB")
             logger.debug(f"🔐 File hash: {file_hash[:16]}...")
-            
+
             return self.cache_file
-            
+
         except requests.RequestException as e:
             logger.error(f"❌ Download failed: {e}")
             # Try to use cached data if available, even if expired
@@ -226,40 +232,40 @@ class CVEDataDownloader:
                 logger.warning("⚠️  Using expired cached data as fallback")
                 return self.cache_file
             raise
-        
+
         except (OSError, json.JSONDecodeError) as e:
             logger.error(f"❌ File or JSON error during download: {e}")
             raise
-    
+
     def download_cna_mapping_files(self) -> None:
         """Download CNA mapping files for proper name resolution"""
         logger.info("🔽 Downloading CNA mapping files...")
-        
+
         try:
             # Download CNA list (use injected HTTP client)
             logger.debug("  📥 Downloading CNA list from CVE.org...")
             response = self._http_client.get(self.cna_list_url, timeout=30)
             response.raise_for_status()
-            
+
             self._data_writer.write_json(self.cna_list_file, response.json())
             logger.debug(f"  ✅ CNA list saved to {self.cna_list_file.name}")
-            
+
             # Download CNA name mapping (use injected HTTP client)
             logger.debug("  📥 Downloading CNA name mapping from CVE.org...")
             response = self._http_client.get(self.cna_name_map_url, timeout=30)
             response.raise_for_status()
-            
+
             self._data_writer.write_json(self.cna_name_map_file, response.json())
             logger.debug(f"  ✅ CNA name mapping saved to {self.cna_name_map_file.name}")
-            
+
             logger.info("✅ CNA mapping files downloaded successfully")
-            
+
         except requests.RequestException as e:
             logger.warning(f"⚠️  Warning: Could not download CNA mapping files: {e}")
             logger.warning("  📝 Will use raw sourceIdentifier values as fallback")
         except (OSError, json.JSONDecodeError) as e:
             logger.warning(f"⚠️  Warning: File or JSON error downloading CNA files: {e}")
-    
+
     # ------------------------------------------------------------------
     # Source manifest handling
     #
@@ -298,8 +304,7 @@ class CVEDataDownloader:
             return None
 
         logger.info(
-            f"📄 Source manifest: {manifest['cve_count']:,} CVEs, "
-            f"run {manifest.get('last_run_iso', 'unknown')}"
+            f"📄 Source manifest: {manifest['cve_count']:,} CVEs, run {manifest.get('last_run_iso', 'unknown')}"
         )
         return manifest
 
@@ -333,8 +338,7 @@ class CVEDataDownloader:
         """
         if manifest.get("degraded"):
             raise ValueError(
-                f"Producer reported a degraded run "
-                f"(last_run_iso={manifest.get('last_run_iso')}). Refusing to ingest."
+                f"Producer reported a degraded run (last_run_iso={manifest.get('last_run_iso')}). Refusing to ingest."
             )
 
         years_via_api = manifest.get("years_via_api") or []
@@ -430,9 +434,7 @@ class CVEDataDownloader:
 
         actual_sha = self.calculate_file_hash_streaming(self.cache_file)
         if actual_sha != expected_sha:
-            raise OSError(
-                f"SHA-256 mismatch: computed {actual_sha}, manifest declares {expected_sha}."
-            )
+            raise OSError(f"SHA-256 mismatch: computed {actual_sha}, manifest declares {expected_sha}.")
         logger.info("✅ SHA-256 verified against manifest")
 
     def persist_accepted_manifest(self, manifest: dict[str, Any]) -> None:
@@ -458,103 +460,101 @@ class CVEDataDownloader:
         content = self._data_reader.read_bytes(file_path)
         hash_sha256.update(content)
         return hash_sha256.hexdigest()
-    
+
     def validate_json_format(self, file_path: Path) -> bool:
         """Validate that the downloaded file contains valid CVE data (JSON array format)"""
         try:
             logger.info("🔍 Validating JSON format...")
-            
+
             try:
                 # Try to load as JSON array using data reader
                 cve_data = self._data_reader.read_json(file_path)
-                
+
                 if not isinstance(cve_data, list):
                     raise ValueError("Expected JSON array format")
-                
+
                 total_records = len(cve_data)
                 valid_cve_count = 0
-                
+
                 logger.debug(f"  📊 Found {total_records:,} records in JSON array")
-                
+
                 # Validate a sample of records
                 sample_size = min(1000, total_records)
                 for i in range(0, total_records, max(1, total_records // sample_size)):
                     if i >= total_records:
                         break
-                        
+
                     record = cve_data[i]
-                    if isinstance(record, dict) and 'cve' in record:
-                        cve_id = record.get('cve', {}).get('id', '')
-                        if cve_id.startswith('CVE-'):
+                    if isinstance(record, dict) and "cve" in record:
+                        cve_id = record.get("cve", {}).get("id", "")
+                        if cve_id.startswith("CVE-"):
                             valid_cve_count += 1
-                
+
                 logger.info("✅ Validation complete:")
                 logger.info(f"  📊 Total records: {total_records:,}")
                 logger.debug(f"  ✅ Valid CVEs (sampled): {valid_cve_count}/{sample_size}")
-                logger.debug(f"  📈 Success rate: {(valid_cve_count/sample_size)*100:.1f}%")
-                
+                logger.debug(f"  📈 Success rate: {(valid_cve_count / sample_size) * 100:.1f}%")
+
                 if valid_cve_count == 0:
                     raise ValueError("No valid CVE records found in downloaded data")
-                
+
                 return True
-                
+
             except json.JSONDecodeError as e:
                 logger.error(f"❌ Failed to parse JSON: {e}")
                 return False
-            
+
         except (json.JSONDecodeError, KeyError, ValueError, OSError) as e:
             logger.error(f"❌ Validation failed: {e}")
             return False
-    
+
     def get_data_stats(self) -> dict[str, Any] | None:
         """Get statistics about the cached data (JSON array format)"""
         if not self._data_reader.exists(self.cache_file):
             return None
-        
+
         try:
             cache_info = self._data_reader.read_json(self.cache_info_file)
-            
+
             # Load and process JSON array
-            with open(self.cache_file, 'r', encoding='utf-8') as f:
+            with open(self.cache_file, encoding="utf-8") as f:
                 cve_data_array = json.load(f)
-            
+
             # Quick scan for year distribution
             year_counts: dict[int, int] = {}
             total_cves = 0
-            
+
             # Sample every 100th record for performance (still gives accurate stats)
             sample_size = max(1, len(cve_data_array) // 100)
             for i in range(0, len(cve_data_array), sample_size):
                 try:
                     cve_record = cve_data_array[i]
-                    cve_id = cve_record.get('cve', {}).get('id', '')
-                    
-                    if cve_id.startswith('CVE-'):
+                    cve_id = cve_record.get("cve", {}).get("id", "")
+
+                    if cve_id.startswith("CVE-"):
                         # Extract year from CVE-YYYY-NNNN format
-                        year = int(cve_id.split('-')[1])
+                        year = int(cve_id.split("-")[1])
                         year_counts[year] = year_counts.get(year, 0) + sample_size
                         total_cves += sample_size
-                
+
                 except (KeyError, ValueError, IndexError):
                     continue
-            
+
             # Adjust for sampling
             actual_total = len(cve_data_array)
-            
+
             return {
-                'cache_info': cache_info,
-                'total_cves': actual_total,
-                'year_range': (min(year_counts.keys()), max(year_counts.keys())) if year_counts else (None, None),
-                'year_counts': dict(sorted(year_counts.items()))
+                "cache_info": cache_info,
+                "total_cves": actual_total,
+                "year_range": (min(year_counts.keys()), max(year_counts.keys())) if year_counts else (None, None),
+                "year_counts": dict(sorted(year_counts.items())),
             }
-            
+
         except (json.JSONDecodeError, KeyError, ValueError, OSError) as e:
             logger.warning(f"⚠️  Could not get data stats: {e}")
             return None
-    
-    def ensure_data_available(
-        self, force_download: bool = False, accept_baseline: bool = False
-    ) -> Path:
+
+    def ensure_data_available(self, force_download: bool = False, accept_baseline: bool = False) -> Path:
         """Main method to ensure CVE data is available and valid.
 
         Args:
@@ -565,24 +565,19 @@ class CVEDataDownloader:
         """
         logger.info("\n🔽 Ensuring CVE data is available...")
         logger.info("=" * 50)
-        
+
         try:
             # Check the producer's manifest before pulling ~1.8GB. A degraded or
             # regressed snapshot is rejected here, at zero bandwidth cost.
             manifest = self.fetch_source_manifest()
             if manifest is not None:
                 if accept_baseline:
-                    logger.warning(
-                        "⚠️  --accept-baseline: skipping manifest regression check"
-                    )
+                    logger.warning("⚠️  --accept-baseline: skipping manifest regression check")
                 else:
                     self.verify_manifest_healthy(manifest)
                     self.verify_manifest_not_regressed(manifest, self.fetch_baseline_manifest())
             else:
-                logger.warning(
-                    "⚠️  Proceeding without manifest verification "
-                    "(producer manifest unavailable)"
-                )
+                logger.warning("⚠️  Proceeding without manifest verification (producer manifest unavailable)")
 
             # Download data if needed
             data_file = self.download_data(force=force_download, manifest=manifest)
@@ -592,29 +587,29 @@ class CVEDataDownloader:
             # a snapshot we did not actually accept.
             if manifest is not None:
                 self.persist_accepted_manifest(manifest)
-            
+
             # Download CNA mapping files
             self.download_cna_mapping_files()
-            
+
             # Validate format
             if not self.validate_json_format(data_file):
                 raise ValueError("Downloaded data failed validation")
-            
+
             # Show statistics
             stats = self.get_data_stats()
             if stats:
                 logger.info("\n📊 Data Statistics:")
                 logger.info(f"  📅 Downloaded: {stats['cache_info']['download_time']}")
                 logger.info(f"  📊 Total CVEs: {stats['total_cves']:,}")
-                if stats['year_range'][0]:
+                if stats["year_range"][0]:
                     logger.info(f"  📅 Year range: {stats['year_range'][0]}-{stats['year_range'][1]}")
                     logger.debug(f"  📈 Years covered: {len(stats['year_counts'])}")
-            
+
             logger.info("\n" + "=" * 50)
             logger.info("✅ CVE data is ready for processing!")
-            
+
             return data_file
-            
+
         except (ValueError, requests.RequestException, OSError) as e:
             logger.error(f"\n❌ Failed to ensure data availability: {e}")
             raise
@@ -687,7 +682,7 @@ class CVEDataDownloader:
         try:
             with gzip.open(epss_csv_gz, mode="rt", encoding="utf-8") as f:
                 # Skip comment lines (start with #)
-                lines = (line for line in f if not line.startswith('#'))
+                lines = (line for line in f if not line.startswith("#"))
                 reader = csv.DictReader(lines)
                 for row in reader:
                     cve_id = row.get("cve") or row.get("CVE")
@@ -789,7 +784,7 @@ class CVEDataDownloader:
             logger.info("🔍 Parsing KEV JSON into CVE mapping...")
 
         try:
-            with open(kev_json, "r", encoding="utf-8") as f:
+            with open(kev_json, encoding="utf-8") as f:
                 raw = json.load(f)
 
             # CISA’s feed wraps the list in a top-level key in most formats
@@ -817,24 +812,27 @@ class CVEDataDownloader:
             logger.warning(f"⚠️  Warning: Failed to parse KEV JSON: {e}")
             return None
 
+
 def main() -> None:
     """Main entry point for standalone execution"""
     import argparse
+
     from data.logging_config import setup_logging
-    
+
     parser = argparse.ArgumentParser(description="Download and cache CVE data")
-    parser.add_argument('--force', action='store_true', help='Force download even if cache is valid')
-    parser.add_argument('--stats', action='store_true', help='Show data statistics only')
-    parser.add_argument('--cache-dir', help='Custom cache directory')
-    parser.add_argument('--log-level', choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'], default='INFO',
-                       help='Logging level')
-    
+    parser.add_argument("--force", action="store_true", help="Force download even if cache is valid")
+    parser.add_argument("--stats", action="store_true", help="Show data statistics only")
+    parser.add_argument("--cache-dir", help="Custom cache directory")
+    parser.add_argument(
+        "--log-level", choices=["DEBUG", "INFO", "WARNING", "ERROR"], default="INFO", help="Logging level"
+    )
+
     args = parser.parse_args()
-    
+
     setup_logging(level=args.log_level)
-    
+
     downloader = CVEDataDownloader(cache_dir=args.cache_dir)
-    
+
     if args.stats:
         stats = downloader.get_data_stats()
         if stats:
@@ -844,5 +842,6 @@ def main() -> None:
     else:
         downloader.ensure_data_available(force_download=args.force)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/data/download_cve_data.py
+++ b/data/download_cve_data.py
@@ -28,8 +28,8 @@ from protocols import (
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/logging_config.py
+++ b/data/logging_config.py
@@ -25,6 +25,7 @@ import sys
 from pathlib import Path
 from typing import Literal
 
+
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 # Default format includes emoji-style indicators for visual scanning

--- a/data/protocols.py
+++ b/data/protocols.py
@@ -10,6 +10,7 @@ Python 3.8+ Protocol classes provide structural subtyping - any class that
 implements the required methods is considered a valid implementation without
 explicit inheritance.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -19,26 +20,20 @@ from typing import Any, Protocol, runtime_checkable
 @runtime_checkable
 class HttpClient(Protocol):
     """Protocol for HTTP client operations.
-    
+
     Abstracts HTTP GET requests to enable mocking in tests.
     Real implementation: requests.Session or httpx.Client
     Test implementation: FakeHttpClient with predefined responses
     """
-    
-    def get(
-        self,
-        url: str,
-        *,
-        timeout: int | None = None,
-        stream: bool = False
-    ) -> HttpResponse:
+
+    def get(self, url: str, *, timeout: int | None = None, stream: bool = False) -> HttpResponse:
         """Perform HTTP GET request.
-        
+
         Args:
             url: The URL to fetch
             timeout: Request timeout in seconds
             stream: Whether to stream the response
-            
+
         Returns:
             HttpResponse object with status_code, content, headers
         """
@@ -48,38 +43,38 @@ class HttpClient(Protocol):
 @runtime_checkable
 class HttpResponse(Protocol):
     """Protocol for HTTP response objects.
-    
+
     Matches the interface of requests.Response for compatibility.
     """
-    
+
     @property
     def status_code(self) -> int:
         """HTTP status code (e.g., 200, 404, 500)"""
         ...
-    
+
     @property
     def content(self) -> bytes:
         """Raw response content as bytes"""
         ...
-    
+
     @property
     def text(self) -> str:
         """Response content decoded as text"""
         ...
-    
+
     @property
     def headers(self) -> dict[str, str]:
         """Response headers"""
         ...
-    
+
     def json(self) -> Any:
         """Parse response as JSON"""
         ...
-    
+
     def raise_for_status(self) -> None:
         """Raise exception if status code indicates error"""
         ...
-    
+
     def iter_content(self, chunk_size: int = 1) -> Any:
         """Iterate over response content in chunks"""
         ...
@@ -88,61 +83,61 @@ class HttpResponse(Protocol):
 @runtime_checkable
 class DataReader(Protocol):
     """Protocol for reading data from various sources.
-    
+
     Abstracts file and data reading to enable testing without
     actual file system access.
     """
-    
+
     def read_json(self, path: Path) -> Any:
         """Read and parse JSON from file.
-        
+
         Args:
             path: Path to JSON file
-            
+
         Returns:
             Parsed JSON data (dict, list, etc.)
         """
         ...
-    
+
     def read_text(self, path: Path) -> str:
         """Read text content from file.
-        
+
         Args:
             path: Path to text file
-            
+
         Returns:
             File contents as string
         """
         ...
-    
+
     def read_bytes(self, path: Path) -> bytes:
         """Read binary content from file.
-        
+
         Args:
             path: Path to binary file
-            
+
         Returns:
             File contents as bytes
         """
         ...
-    
+
     def exists(self, path: Path) -> bool:
         """Check if path exists.
-        
+
         Args:
             path: Path to check
-            
+
         Returns:
             True if path exists, False otherwise
         """
         ...
-    
+
     def list_dir(self, path: Path) -> list[Path]:
         """List directory contents.
-        
+
         Args:
             path: Directory path
-            
+
         Returns:
             List of paths in directory
         """
@@ -152,42 +147,42 @@ class DataReader(Protocol):
 @runtime_checkable
 class DataWriter(Protocol):
     """Protocol for writing data to various destinations.
-    
+
     Abstracts file writing to enable testing without
     actual file system modifications.
     """
-    
+
     def write_json(self, path: Path, data: Any, indent: int = 2) -> None:
         """Write data as JSON to file.
-        
+
         Args:
             path: Path to write to
             data: Data to serialize as JSON
             indent: JSON indentation level
         """
         ...
-    
+
     def write_text(self, path: Path, content: str) -> None:
         """Write text content to file.
-        
+
         Args:
             path: Path to write to
             content: Text content to write
         """
         ...
-    
+
     def write_bytes(self, path: Path, content: bytes) -> None:
         """Write binary content to file.
-        
+
         Args:
             path: Path to write to
             content: Binary content to write
         """
         ...
-    
+
     def mkdir(self, path: Path, parents: bool = True, exist_ok: bool = True) -> None:
         """Create directory.
-        
+
         Args:
             path: Directory path to create
             parents: Create parent directories if needed
@@ -199,45 +194,45 @@ class DataWriter(Protocol):
 @runtime_checkable
 class CacheManager(Protocol):
     """Protocol for cache management operations.
-    
+
     Abstracts caching logic for data downloads and processing results.
     """
-    
+
     def is_valid(self, key: str) -> bool:
         """Check if cache entry is valid and not expired.
-        
+
         Args:
             key: Cache key to check
-            
+
         Returns:
             True if cache is valid, False if expired or missing
         """
         ...
-    
+
     def get(self, key: str) -> Any | None:
         """Get cached value.
-        
+
         Args:
             key: Cache key
-            
+
         Returns:
             Cached value or None if not found
         """
         ...
-    
+
     def set(self, key: str, value: Any, ttl_seconds: int | None = None) -> None:
         """Set cache value.
-        
+
         Args:
             key: Cache key
             value: Value to cache
             ttl_seconds: Time-to-live in seconds (None for default)
         """
         ...
-    
+
     def invalidate(self, key: str) -> None:
         """Invalidate cache entry.
-        
+
         Args:
             key: Cache key to invalidate
         """
@@ -248,29 +243,31 @@ class CacheManager(Protocol):
 # Default implementations for production use
 # =============================================================================
 
+
 class FileSystemDataReader:
     """Default DataReader implementation using the file system."""
-    
+
     def read_json(self, path: Path) -> Any:
         """Read and parse JSON from file."""
         import json
-        with open(path, 'r', encoding='utf-8') as f:
+
+        with open(path, encoding="utf-8") as f:
             return json.load(f)
-    
+
     def read_text(self, path: Path) -> str:
         """Read text content from file."""
-        with open(path, 'r', encoding='utf-8') as f:
+        with open(path, encoding="utf-8") as f:
             return f.read()
-    
+
     def read_bytes(self, path: Path) -> bytes:
         """Read binary content from file."""
-        with open(path, 'rb') as f:
+        with open(path, "rb") as f:
             return f.read()
-    
+
     def exists(self, path: Path) -> bool:
         """Check if path exists."""
         return path.exists()
-    
+
     def list_dir(self, path: Path) -> list[Path]:
         """List directory contents."""
         return list(path.iterdir()) if path.is_dir() else []
@@ -278,23 +275,24 @@ class FileSystemDataReader:
 
 class FileSystemDataWriter:
     """Default DataWriter implementation using the file system."""
-    
+
     def write_json(self, path: Path, data: Any, indent: int = 2) -> None:
         """Write data as JSON to file."""
         import json
-        with open(path, 'w', encoding='utf-8') as f:
+
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=indent)
-    
+
     def write_text(self, path: Path, content: str) -> None:
         """Write text content to file."""
-        with open(path, 'w', encoding='utf-8') as f:
+        with open(path, "w", encoding="utf-8") as f:
             f.write(content)
-    
+
     def write_bytes(self, path: Path, content: bytes) -> None:
         """Write binary content to file."""
-        with open(path, 'wb') as f:
+        with open(path, "wb") as f:
             f.write(content)
-    
+
     def mkdir(self, path: Path, parents: bool = True, exist_ok: bool = True) -> None:
         """Create directory."""
         path.mkdir(parents=parents, exist_ok=exist_ok)
@@ -302,19 +300,14 @@ class FileSystemDataWriter:
 
 class RequestsHttpClient:
     """Default HttpClient implementation using requests library."""
-    
+
     def __init__(self, session: Any | None = None) -> None:
         """Initialize with optional requests.Session."""
         import requests
+
         self._session = session or requests.Session()
-    
-    def get(
-        self,
-        url: str,
-        *,
-        timeout: int | None = None,
-        stream: bool = False
-    ) -> Any:
+
+    def get(self, url: str, *, timeout: int | None = None, stream: bool = False) -> Any:
         """Perform HTTP GET request."""
         return self._session.get(url, timeout=timeout, stream=stream)
 
@@ -323,15 +316,16 @@ class RequestsHttpClient:
 # Async Protocol and Implementation for Parallel Downloads
 # =============================================================================
 
+
 @runtime_checkable
 class AsyncHttpClient(Protocol):
     """Protocol for async HTTP client operations.
-    
+
     Enables parallel HTTP requests using asyncio.
     Real implementation: httpx.AsyncClient
     Test implementation: FakeAsyncHttpClient
     """
-    
+
     async def get(
         self,
         url: str,
@@ -339,20 +333,20 @@ class AsyncHttpClient(Protocol):
         timeout: int | None = None,
     ) -> HttpResponse:
         """Perform async HTTP GET request.
-        
+
         Args:
             url: The URL to fetch
             timeout: Request timeout in seconds
-            
+
         Returns:
             HttpResponse object with status_code, content, headers
         """
         ...
-    
-    async def __aenter__(self) -> "AsyncHttpClient":
+
+    async def __aenter__(self) -> AsyncHttpClient:
         """Async context manager entry."""
         ...
-    
+
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Async context manager exit."""
         ...
@@ -360,9 +354,9 @@ class AsyncHttpClient(Protocol):
 
 class HttpxAsyncClient:
     """Async HTTP client implementation using httpx library.
-    
+
     Supports parallel downloads via asyncio.gather().
-    
+
     Example:
         async with HttpxAsyncClient() as client:
             responses = await asyncio.gather(
@@ -370,23 +364,24 @@ class HttpxAsyncClient:
                 client.get('https://api2.example.com'),
             )
     """
-    
+
     def __init__(self, timeout: int = 120) -> None:
         """Initialize with default timeout."""
         self._timeout = timeout
         self._client: Any = None
-    
-    async def __aenter__(self) -> "HttpxAsyncClient":
+
+    async def __aenter__(self) -> HttpxAsyncClient:
         """Create httpx.AsyncClient on context entry."""
         import httpx
+
         self._client = httpx.AsyncClient(timeout=self._timeout)
         return self
-    
+
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Close httpx.AsyncClient on context exit."""
         if self._client:
             await self._client.aclose()
-    
+
     async def get(
         self,
         url: str,
@@ -397,4 +392,3 @@ class HttpxAsyncClient:
         if self._client is None:
             raise RuntimeError("Client not initialized. Use 'async with' context manager.")
         return await self._client.get(url, timeout=timeout or self._timeout)
-

--- a/data/scoring_analysis.py
+++ b/data/scoring_analysis.py
@@ -3,14 +3,16 @@
 Scoring Analysis Module for CVE.ICU
 Generates analysis files for the Scoring Hub: EPSS, KEV, and Risk Matrix data
 """
+
 from __future__ import annotations
 
 import json
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
 
 try:
     from data.logging_config import get_logger
@@ -23,66 +25,67 @@ logger = get_logger(__name__)
 @dataclass
 class ScoringAnalyzer:
     """Generates scoring-related analysis files for the Scoring Hub"""
+
     base_dir: Path | None = None
     cache_dir: Path | None = None
     output_dir: Path | None = None
     epss_file: Path = field(init=False)
     kev_file: Path = field(init=False)
     nvd_file: Path = field(init=False)
-    
+
     def __post_init__(self) -> None:
         """Set up paths with defaults if not provided."""
         if self.base_dir is None:
             self.base_dir = Path(__file__).parent.parent
         else:
             self.base_dir = Path(self.base_dir)
-        
+
         if self.cache_dir is None:
-            self.cache_dir = self.base_dir / 'data' / 'cache'
+            self.cache_dir = self.base_dir / "data" / "cache"
         else:
             self.cache_dir = Path(self.cache_dir)
-        
+
         if self.output_dir is None:
-            self.output_dir = self.base_dir / 'web' / 'data'
+            self.output_dir = self.base_dir / "web" / "data"
         else:
             self.output_dir = Path(self.output_dir)
-        
+
         # Source files
-        self.epss_file = self.cache_dir / 'epss_scores-current.json'
-        self.kev_file = self.cache_dir / 'known_exploited_vulnerabilities.json'
-        self.nvd_file = self.cache_dir / 'nvd.json'
-        
+        self.epss_file = self.cache_dir / "epss_scores-current.json"
+        self.kev_file = self.cache_dir / "known_exploited_vulnerabilities.json"
+        self.nvd_file = self.cache_dir / "nvd.json"
+
     def load_epss_data(self) -> dict[str, dict[str, float]]:
         """Load EPSS scores from parsed JSON"""
         if not self.epss_file.exists():
             logger.warning(f"⚠️  EPSS file not found: {self.epss_file}")
             return {}
-        
-        with open(self.epss_file, 'r') as f:
+
+        with open(self.epss_file) as f:
             return json.load(f)
-    
+
     def load_nvd_publication_dates(self) -> dict[str, str]:
         """Load CVE publication dates from NVD data.
-        
+
         Returns a dict mapping CVE ID -> publication year (e.g., "2024")
         """
         if not self.nvd_file.exists():
             logger.warning(f"⚠️  NVD file not found: {self.nvd_file}")
             return {}
-        
+
         logger.debug("  📂 Loading NVD publication dates...")
         pub_dates: dict[str, str] = {}
-        
+
         try:
-            with open(self.nvd_file, 'r') as f:
+            with open(self.nvd_file) as f:
                 nvd_data = json.load(f)
-            
+
             # NVD data is a list of items with 'cve' key
             if isinstance(nvd_data, list):
                 for item in nvd_data:
-                    cve = item.get('cve', {})
-                    cve_id = cve.get('id', '')
-                    published = cve.get('published', '')
+                    cve = item.get("cve", {})
+                    cve_id = cve.get("id", "")
+                    published = cve.get("published", "")
                     if cve_id and published:
                         # Extract year from ISO date like "2024-01-15T04:00:00.000"
                         try:
@@ -91,178 +94,174 @@ class ScoringAnalyzer:
                                 pub_dates[cve_id] = pub_year
                         except (IndexError, ValueError):
                             pass
-            
+
             logger.debug(f"  ✅ Loaded publication dates for {len(pub_dates):,} CVEs")
             return pub_dates
-            
+
         except (json.JSONDecodeError, OSError) as e:
             logger.warning(f"⚠️  Error loading NVD data: {e}")
             return {}
-    
+
     def load_kev_data(self) -> dict[str, Any]:
         """Load KEV data from CISA JSON"""
         if not self.kev_file.exists():
             logger.warning(f"⚠️  KEV file not found: {self.kev_file}")
-            return {'vulnerabilities': []}
-        
-        with open(self.kev_file, 'r') as f:
+            return {"vulnerabilities": []}
+
+        with open(self.kev_file) as f:
             return json.load(f)
-    
+
     def load_cvss_data(self) -> dict[str, Any]:
         """Load CVSS data from existing analysis file or count from NVD"""
-        cvss_file = self.output_dir / 'cvss_analysis.json'
+        cvss_file = self.output_dir / "cvss_analysis.json"
         if cvss_file.exists():
-            with open(cvss_file, 'r') as f:
+            with open(cvss_file) as f:
                 return json.load(f)
-        
+
         # Fallback: count CVSS from NVD data directly
         logger.warning(f"⚠️  CVSS analysis file not found: {cvss_file}")
-        logger.info(f"    📂 Counting CVSS from NVD data directly...")
-        
+        logger.info("    📂 Counting CVSS from NVD data directly...")
+
         if not self.nvd_file.exists():
-            return {'total_cves_with_cvss': 0}
-        
+            return {"total_cves_with_cvss": 0}
+
         try:
-            with open(self.nvd_file, 'r') as f:
+            with open(self.nvd_file) as f:
                 nvd_data = json.load(f)
-            
+
             count = 0
             # NVD data is a list of items with 'cve' key
             if isinstance(nvd_data, list):
                 for item in nvd_data:
-                    cve = item.get('cve', {})
-                    metrics = cve.get('metrics', {})
-                    if metrics.get('cvssMetricV31') or metrics.get('cvssMetricV30') or metrics.get('cvssMetricV2'):
+                    cve = item.get("cve", {})
+                    metrics = cve.get("metrics", {})
+                    if metrics.get("cvssMetricV31") or metrics.get("cvssMetricV30") or metrics.get("cvssMetricV2"):
                         count += 1
             else:
                 # Old format: dict keyed by CVE ID
                 for cve_id, cve_data in nvd_data.items():
-                    if cve_data.get('cvss_v3') or cve_data.get('cvss_v2'):
+                    if cve_data.get("cvss_v3") or cve_data.get("cvss_v2"):
                         count += 1
-            
+
             logger.info(f"    ✅ Found {count:,} CVEs with CVSS scores")
-            return {'total_cves_with_cvss': count}
+            return {"total_cves_with_cvss": count}
         except (FileNotFoundError, json.JSONDecodeError, KeyError, OSError) as e:
             logger.error(f"    ❌ Error loading NVD data: {e}")
-            return {'total_cves_with_cvss': 0}
-    
+            return {"total_cves_with_cvss": 0}
+
     def generate_epss_analysis(self) -> dict[str, Any] | None:
         """Generate EPSS-focused analysis JSON"""
         logger.info("📊 Generating EPSS analysis...")
-        
+
         epss_data = self.load_epss_data()
         if not epss_data:
             logger.warning("  ⚠️  No EPSS data available")
             return None
-        
+
         # Calculate distributions
         buckets = {
-            'very_low': 0,      # 0 - 0.01
-            'low': 0,           # 0.01 - 0.1
-            'medium': 0,        # 0.1 - 0.3
-            'high': 0,          # 0.3 - 0.5
-            'very_high': 0,     # 0.5 - 0.7
-            'critical': 0       # 0.7+
+            "very_low": 0,  # 0 - 0.01
+            "low": 0,  # 0.01 - 0.1
+            "medium": 0,  # 0.1 - 0.3
+            "high": 0,  # 0.3 - 0.5
+            "very_high": 0,  # 0.5 - 0.7
+            "critical": 0,  # 0.7+
         }
-        
+
         percentile_buckets = defaultdict(int)  # 0-10, 10-20, etc.
-        year_coverage = defaultdict(lambda: {'total': 0, 'with_epss': 0})
+        year_coverage = defaultdict(lambda: {"total": 0, "with_epss": 0})
         high_risk_cves = []  # EPSS > 0.5
-        
+
         for cve_id, scores in epss_data.items():
-            score = scores.get('epss_score', 0)
-            percentile = scores.get('epss_percentile', 0)
-            
+            score = scores.get("epss_score", 0)
+            percentile = scores.get("epss_percentile", 0)
+
             # Extract year from CVE ID
             try:
-                year = cve_id.split('-')[1]
-                year_coverage[year]['with_epss'] += 1
+                year = cve_id.split("-")[1]
+                year_coverage[year]["with_epss"] += 1
             except (IndexError, ValueError):
                 pass
-            
+
             # Score buckets using match/case with guard patterns
             match score:
                 case s if s < 0.01:
-                    buckets['very_low'] += 1
+                    buckets["very_low"] += 1
                 case s if s < 0.1:
-                    buckets['low'] += 1
+                    buckets["low"] += 1
                 case s if s < 0.3:
-                    buckets['medium'] += 1
+                    buckets["medium"] += 1
                 case s if s < 0.5:
-                    buckets['high'] += 1
+                    buckets["high"] += 1
                 case s if s < 0.7:
-                    buckets['very_high'] += 1
+                    buckets["very_high"] += 1
                 case _:
-                    buckets['critical'] += 1
-            
+                    buckets["critical"] += 1
+
             # Percentile buckets (for histogram)
             bucket_idx = min(int(percentile * 10), 9)  # 0-9
             percentile_buckets[bucket_idx] += 1
-            
+
             # High risk list (top by EPSS)
             if score >= 0.5:
-                high_risk_cves.append({
-                    'cve_id': cve_id,
-                    'epss_score': score,
-                    'epss_percentile': percentile
-                })
-        
+                high_risk_cves.append({"cve_id": cve_id, "epss_score": score, "epss_percentile": percentile})
+
         # Sort high risk by score descending, limit to top 100
-        high_risk_cves.sort(key=lambda x: x['epss_score'], reverse=True)
+        high_risk_cves.sort(key=lambda x: x["epss_score"], reverse=True)
         high_risk_cves = high_risk_cves[:100]
-        
+
         # Calculate statistics
-        all_scores = [s['epss_score'] for s in epss_data.values()]
+        all_scores = [s["epss_score"] for s in epss_data.values()]
         avg_score = sum(all_scores) / len(all_scores) if all_scores else 0
-        
+
         # Threshold counts
         gt_01 = sum(1 for s in all_scores if s > 0.1)
         gt_03 = sum(1 for s in all_scores if s > 0.3)
         gt_05 = sum(1 for s in all_scores if s > 0.5)
         gt_07 = sum(1 for s in all_scores if s > 0.7)
         gt_09 = sum(1 for s in all_scores if s > 0.9)
-        
+
         analysis = {
-            'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
-            'total_cves_with_epss': len(epss_data),
-            'statistics': {
-                'average_score': round(avg_score, 6),
-                'gt_0_1': gt_01,
-                'gt_0_3': gt_03,
-                'gt_0_5': gt_05,
-                'gt_0_7': gt_07,
-                'gt_0_9': gt_09
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "total_cves_with_epss": len(epss_data),
+            "statistics": {
+                "average_score": round(avg_score, 6),
+                "gt_0_1": gt_01,
+                "gt_0_3": gt_03,
+                "gt_0_5": gt_05,
+                "gt_0_7": gt_07,
+                "gt_0_9": gt_09,
             },
-            'score_buckets': buckets,
-            'percentile_distribution': dict(sorted(percentile_buckets.items())),
-            'year_coverage': dict(sorted(year_coverage.items())),
-            'high_risk_cves': high_risk_cves
+            "score_buckets": buckets,
+            "percentile_distribution": dict(sorted(percentile_buckets.items())),
+            "year_coverage": dict(sorted(year_coverage.items())),
+            "high_risk_cves": high_risk_cves,
         }
-        
-        output_file = self.output_dir / 'epss_analysis.json'
-        with open(output_file, 'w') as f:
+
+        output_file = self.output_dir / "epss_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(analysis, f, indent=2)
-        
+
         logger.info(f"  ✅ Generated {output_file.name}")
         logger.info(f"     Total CVEs with EPSS: {len(epss_data):,}")
         logger.info(f"     High risk (>0.5): {gt_05:,}")
-        
+
         return analysis
-    
+
     def generate_kev_analysis(self) -> dict[str, Any] | None:
         """Generate KEV-focused analysis JSON"""
         logger.info("📊 Generating KEV analysis...")
-        
+
         kev_data = self.load_kev_data()
-        vulnerabilities = kev_data.get('vulnerabilities', [])
-        
+        vulnerabilities = kev_data.get("vulnerabilities", [])
+
         if not vulnerabilities:
             logger.warning("  ⚠️  No KEV data available")
             return None
-        
+
         # Load NVD publication dates for accurate published year
         nvd_pub_dates = self.load_nvd_publication_dates()
-        
+
         # Aggregations
         by_year_added = defaultdict(int)
         by_year_cve = defaultdict(int)  # Year from CVE ID (CVE-YYYY-NNNN)
@@ -271,340 +270,328 @@ class ScoringAnalyzer:
         by_product = defaultdict(int)
         by_cwe = defaultdict(int)
         ransomware_count = 0
-        
+
         recent_30_days = []
         recent_90_days = []
-        now = datetime.now(timezone.utc)
-        
+        now = datetime.now(UTC)
+
         timeline = defaultdict(int)  # Monthly additions
-        
+
         for vuln in vulnerabilities:
-            cve_id = vuln.get('cveID', '')
-            vendor = vuln.get('vendorProject', 'Unknown')
-            product = vuln.get('product', 'Unknown')
-            date_added = vuln.get('dateAdded', '')
-            cwes = vuln.get('cwes', [])
-            ransomware = vuln.get('knownRansomwareCampaignUse', 'Unknown')
-            
+            cve_id = vuln.get("cveID", "")
+            vendor = vuln.get("vendorProject", "Unknown")
+            product = vuln.get("product", "Unknown")
+            date_added = vuln.get("dateAdded", "")
+            cwes = vuln.get("cwes", [])
+            ransomware = vuln.get("knownRansomwareCampaignUse", "Unknown")
+
             # Year from CVE ID (CVE-YYYY-NNNN) - not reliable for publication date
             try:
-                cve_year = cve_id.split('-')[1]
+                cve_year = cve_id.split("-")[1]
                 by_year_cve[cve_year] += 1
             except (IndexError, ValueError):
                 pass
-            
+
             # Actual publication year from NVD
             if cve_id in nvd_pub_dates:
                 by_year_published[nvd_pub_dates[cve_id]] += 1
-            
+
             # Year added to KEV
             if date_added:
                 try:
-                    added_date = datetime.strptime(date_added, '%Y-%m-%d').replace(tzinfo=timezone.utc)
+                    added_date = datetime.strptime(date_added, "%Y-%m-%d").replace(tzinfo=UTC)
                     by_year_added[str(added_date.year)] += 1
-                    
+
                     # Monthly timeline
-                    month_key = added_date.strftime('%Y-%m')
+                    month_key = added_date.strftime("%Y-%m")
                     timeline[month_key] += 1
-                    
+
                     # Recent additions
                     days_ago = (now - added_date).days
                     if days_ago <= 30:
-                        recent_30_days.append({
-                            'cve_id': cve_id,
-                            'vendor': vendor,
-                            'product': product,
-                            'date_added': date_added,
-                            'due_date': vuln.get('dueDate', ''),
-                            'ransomware': ransomware
-                        })
+                        recent_30_days.append(
+                            {
+                                "cve_id": cve_id,
+                                "vendor": vendor,
+                                "product": product,
+                                "date_added": date_added,
+                                "due_date": vuln.get("dueDate", ""),
+                                "ransomware": ransomware,
+                            }
+                        )
                     if days_ago <= 90:
-                        recent_90_days.append({
-                            'cve_id': cve_id,
-                            'vendor': vendor,
-                            'product': product,
-                            'date_added': date_added
-                        })
+                        recent_90_days.append(
+                            {"cve_id": cve_id, "vendor": vendor, "product": product, "date_added": date_added}
+                        )
                 except ValueError:
                     pass
-            
+
             # Vendor and product
             by_vendor[vendor] += 1
             by_product[f"{vendor} - {product}"] += 1
-            
+
             # CWEs
             for cwe in cwes:
                 by_cwe[cwe] += 1
-            
+
             # Ransomware
-            if ransomware and ransomware.lower() not in ['unknown', 'no']:
+            if ransomware and ransomware.lower() not in ["unknown", "no"]:
                 ransomware_count += 1
-        
+
         # Sort and limit top lists
         top_vendors = sorted(by_vendor.items(), key=lambda x: x[1], reverse=True)[:20]
         top_products = sorted(by_product.items(), key=lambda x: x[1], reverse=True)[:20]
         top_cwes = sorted(by_cwe.items(), key=lambda x: x[1], reverse=True)[:20]
-        
+
         # Sort recent by date
-        recent_30_days.sort(key=lambda x: x['date_added'], reverse=True)
-        recent_90_days.sort(key=lambda x: x['date_added'], reverse=True)
-        
+        recent_30_days.sort(key=lambda x: x["date_added"], reverse=True)
+        recent_90_days.sort(key=lambda x: x["date_added"], reverse=True)
+
         analysis = {
-            'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
-            'catalog_version': kev_data.get('catalogVersion', ''),
-            'total_kev_cves': len(vulnerabilities),
-            'statistics': {
-                'added_last_30_days': len(recent_30_days),
-                'added_last_90_days': len(recent_90_days),
-                'ransomware_associated': ransomware_count
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "catalog_version": kev_data.get("catalogVersion", ""),
+            "total_kev_cves": len(vulnerabilities),
+            "statistics": {
+                "added_last_30_days": len(recent_30_days),
+                "added_last_90_days": len(recent_90_days),
+                "ransomware_associated": ransomware_count,
             },
-            'by_year_added': dict(sorted(by_year_added.items())),
-            'by_year_cve': dict(sorted(by_year_cve.items())),
-            'by_year_published': dict(sorted(by_year_published.items())),
-            'timeline': dict(sorted(timeline.items())),
-            'top_vendors': top_vendors,
-            'top_products': top_products,
-            'top_cwes': top_cwes,
-            'recent_additions': recent_30_days[:20]  # Last 20 for display
+            "by_year_added": dict(sorted(by_year_added.items())),
+            "by_year_cve": dict(sorted(by_year_cve.items())),
+            "by_year_published": dict(sorted(by_year_published.items())),
+            "timeline": dict(sorted(timeline.items())),
+            "top_vendors": top_vendors,
+            "top_products": top_products,
+            "top_cwes": top_cwes,
+            "recent_additions": recent_30_days[:20],  # Last 20 for display
         }
-        
-        output_file = self.output_dir / 'kev_analysis.json'
-        with open(output_file, 'w') as f:
+
+        output_file = self.output_dir / "kev_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(analysis, f, indent=2)
-        
+
         logger.info(f"  ✅ Generated {output_file.name}")
         logger.info(f"     Total KEV CVEs: {len(vulnerabilities):,}")
         logger.info(f"     Added last 30 days: {len(recent_30_days)}")
-        
+
         return analysis
-    
+
     def generate_risk_matrix(self) -> dict[str, Any]:
         """Generate bucketed CVSS × EPSS risk matrix data"""
         logger.info("📊 Generating risk matrix...")
-        
+
         epss_data = self.load_epss_data()
         self.load_cvss_data()
         kev_data = self.load_kev_data()
-        
+
         # Build KEV set for quick lookup using set comprehension with walrus
-        kev_set = {
-            cve_id
-            for vuln in kev_data.get('vulnerabilities', [])
-            if (cve_id := vuln.get('cveID', ''))
-        }
-        
+        kev_set = {cve_id for vuln in kev_data.get("vulnerabilities", []) if (cve_id := vuln.get("cveID", ""))}
+
         # CVSS severity bands
-        severity_bands = ['NONE', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL']
-        
+        severity_bands = ["NONE", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
+
         # EPSS buckets
-        epss_buckets = ['0-0.1', '0.1-0.3', '0.3-0.5', '0.5-0.7', '0.7+']
-        
+        epss_buckets = ["0-0.1", "0.1-0.3", "0.3-0.5", "0.5-0.7", "0.7+"]
+
         def get_epss_bucket(score):
             match score:
                 case s if s < 0.1:
-                    return '0-0.1'
+                    return "0-0.1"
                 case s if s < 0.3:
-                    return '0.1-0.3'
+                    return "0.1-0.3"
                 case s if s < 0.5:
-                    return '0.3-0.5'
+                    return "0.3-0.5"
                 case s if s < 0.7:
-                    return '0.5-0.7'
+                    return "0.5-0.7"
                 case _:
-                    return '0.7+'
-        
+                    return "0.7+"
+
         def get_severity_from_score(score):
             match score:
                 case 0:
-                    return 'NONE'
+                    return "NONE"
                 case s if s < 4.0:
-                    return 'LOW'
+                    return "LOW"
                 case s if s < 7.0:
-                    return 'MEDIUM'
+                    return "MEDIUM"
                 case s if s < 9.0:
-                    return 'HIGH'
+                    return "HIGH"
                 case _:
-                    return 'CRITICAL'
-        
+                    return "CRITICAL"
+
         # Initialize matrix
         matrix = {}
         for severity in severity_bands:
             for epss_bucket in epss_buckets:
                 key = f"{severity}_{epss_bucket}"
-                matrix[key] = {
-                    'severity': severity,
-                    'epss_bucket': epss_bucket,
-                    'count': 0,
-                    'kev_count': 0
-                }
-        
+                matrix[key] = {"severity": severity, "epss_bucket": epss_bucket, "count": 0, "kev_count": 0}
+
         # We need to correlate EPSS with CVSS scores
         # Load yearly files to get CVSS scores per CVE
         # For now, use the severity distribution from cvss_analysis
         # This is a simplified approach - in production we'd scan nvd.json
-        
+
         # For the matrix, we'll estimate based on overall distributions
         # and the EPSS data we have
-        
+
         # Actually, let's load the NVD data to get proper CVSS scores
         if self.nvd_file.exists():
             logger.info("  📂 Loading NVD data for CVSS correlation...")
-            with open(self.nvd_file, 'r') as f:
+            with open(self.nvd_file) as f:
                 nvd_data = json.load(f)
-            
+
             for record in nvd_data:
-                cve_info = record.get('cve', {})
-                cve_id = cve_info.get('id', '')
-                
+                cve_info = record.get("cve", {})
+                cve_id = cve_info.get("id", "")
+
                 if cve_id not in epss_data:
                     continue
-                
-                epss_score = epss_data[cve_id].get('epss_score', 0)
+
+                epss_score = epss_data[cve_id].get("epss_score", 0)
                 epss_bucket = get_epss_bucket(epss_score)
-                
+
                 # Get CVSS score - try v3.1, v3.0, v2.0, v4.0
                 cvss_score = None
-                metrics = cve_info.get('metrics', {})
-                
-                for version in ['cvssMetricV31', 'cvssMetricV30', 'cvssMetricV40', 'cvssMetricV2']:
+                metrics = cve_info.get("metrics", {})
+
+                for version in ["cvssMetricV31", "cvssMetricV30", "cvssMetricV40", "cvssMetricV2"]:
                     if version in metrics and metrics[version]:
                         metric = metrics[version][0]
-                        cvss_data_inner = metric.get('cvssData', {})
-                        if cvss_score := cvss_data_inner.get('baseScore'):
+                        cvss_data_inner = metric.get("cvssData", {})
+                        if cvss_score := cvss_data_inner.get("baseScore"):
                             break
-                
+
                 if cvss_score is None:
                     continue
-                
+
                 severity = get_severity_from_score(cvss_score)
                 key = f"{severity}_{epss_bucket}"
-                
-                matrix[key]['count'] += 1
+
+                matrix[key]["count"] += 1
                 if cve_id in kev_set:
-                    matrix[key]['kev_count'] += 1
+                    matrix[key]["kev_count"] += 1
         else:
             logger.warning("  ⚠️  NVD file not found, using estimated data")
-        
+
         # Convert to list format for easier charting
         matrix_list = list(matrix.values())
-        
+
         # Calculate totals
-        total_in_matrix = sum(m['count'] for m in matrix_list)
-        total_kev_in_matrix = sum(m['kev_count'] for m in matrix_list)
-        
+        total_in_matrix = sum(m["count"] for m in matrix_list)
+        total_kev_in_matrix = sum(m["kev_count"] for m in matrix_list)
+
         analysis = {
-            'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
-            'severity_bands': severity_bands,
-            'epss_buckets': epss_buckets,
-            'matrix': matrix_list,
-            'totals': {
-                'cves_in_matrix': total_in_matrix,
-                'kev_in_matrix': total_kev_in_matrix
-            }
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "severity_bands": severity_bands,
+            "epss_buckets": epss_buckets,
+            "matrix": matrix_list,
+            "totals": {"cves_in_matrix": total_in_matrix, "kev_in_matrix": total_kev_in_matrix},
         }
-        
-        output_file = self.output_dir / 'risk_matrix.json'
-        with open(output_file, 'w') as f:
+
+        output_file = self.output_dir / "risk_matrix.json"
+        with open(output_file, "w") as f:
             json.dump(analysis, f, indent=2)
-        
+
         logger.info(f"  ✅ Generated {output_file.name}")
         logger.info(f"     CVEs in matrix: {total_in_matrix:,}")
         logger.info(f"     KEV in matrix: {total_kev_in_matrix:,}")
-        
+
         return analysis
-    
+
     def generate_scoring_comparison(self) -> dict[str, Any]:
         """Generate comparison data for the Scoring Hub landing page"""
         logger.info("📊 Generating scoring comparison...")
-        
+
         epss_data = self.load_epss_data()
         kev_data = self.load_kev_data()
         cvss_data = self.load_cvss_data()
-        
-        kev_vulnerabilities = kev_data.get('vulnerabilities', [])
-        kev_set = {v.get('cveID', '') for v in kev_vulnerabilities}
-        
+
+        kev_vulnerabilities = kev_data.get("vulnerabilities", [])
+        kev_set = {v.get("cveID", "") for v in kev_vulnerabilities}
+
         # Count overlaps
         epss_and_kev = sum(1 for cve_id in epss_data if cve_id in kev_set)
-        
+
         # High EPSS in KEV
         high_epss_in_kev = sum(
-            1 for cve_id, scores in epss_data.items() 
-            if cve_id in kev_set and scores.get('epss_score', 0) > 0.5
+            1 for cve_id, scores in epss_data.items() if cve_id in kev_set and scores.get("epss_score", 0) > 0.5
         )
-        
+
         comparison = {
-            'generated_at': datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
-            'systems': {
-                'cvss': {
-                    'name': 'CVSS',
-                    'full_name': 'Common Vulnerability Scoring System',
-                    'description': 'Measures severity/impact of vulnerabilities',
-                    'question': 'How bad is it?',
-                    'total_scored': cvss_data.get('total_cves_with_cvss', 0),
-                    'source': 'NVD / Vendors',
-                    'update_frequency': 'Per CVE publication'
+            "generated_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "systems": {
+                "cvss": {
+                    "name": "CVSS",
+                    "full_name": "Common Vulnerability Scoring System",
+                    "description": "Measures severity/impact of vulnerabilities",
+                    "question": "How bad is it?",
+                    "total_scored": cvss_data.get("total_cves_with_cvss", 0),
+                    "source": "NVD / Vendors",
+                    "update_frequency": "Per CVE publication",
                 },
-                'epss': {
-                    'name': 'EPSS',
-                    'full_name': 'Exploit Prediction Scoring System',
-                    'description': 'Predicts likelihood of exploitation in 30 days',
-                    'question': 'Will it be exploited?',
-                    'total_scored': len(epss_data),
-                    'source': 'FIRST.org',
-                    'update_frequency': 'Daily'
+                "epss": {
+                    "name": "EPSS",
+                    "full_name": "Exploit Prediction Scoring System",
+                    "description": "Predicts likelihood of exploitation in 30 days",
+                    "question": "Will it be exploited?",
+                    "total_scored": len(epss_data),
+                    "source": "FIRST.org",
+                    "update_frequency": "Daily",
                 },
-                'kev': {
-                    'name': 'KEV',
-                    'full_name': 'Known Exploited Vulnerabilities',
-                    'description': 'Confirmed actively exploited vulnerabilities',
-                    'question': 'Is it being exploited?',
-                    'total_scored': len(kev_vulnerabilities),
-                    'source': 'CISA',
-                    'update_frequency': 'As exploits are confirmed'
-                }
+                "kev": {
+                    "name": "KEV",
+                    "full_name": "Known Exploited Vulnerabilities",
+                    "description": "Confirmed actively exploited vulnerabilities",
+                    "question": "Is it being exploited?",
+                    "total_scored": len(kev_vulnerabilities),
+                    "source": "CISA",
+                    "update_frequency": "As exploits are confirmed",
+                },
             },
-            'overlaps': {
-                'epss_and_kev': epss_and_kev,
-                'high_epss_in_kev': high_epss_in_kev,
-                'kev_coverage_by_epss': round(epss_and_kev / len(kev_vulnerabilities) * 100, 1) if kev_vulnerabilities else 0
+            "overlaps": {
+                "epss_and_kev": epss_and_kev,
+                "high_epss_in_kev": high_epss_in_kev,
+                "kev_coverage_by_epss": round(epss_and_kev / len(kev_vulnerabilities) * 100, 1)
+                if kev_vulnerabilities
+                else 0,
             },
-            'insights': {
-                'epss_gt_05_not_kev': sum(
-                    1 for cve_id, scores in epss_data.items()
-                    if scores.get('epss_score', 0) > 0.5 and cve_id not in kev_set
+            "insights": {
+                "epss_gt_05_not_kev": sum(
+                    1
+                    for cve_id, scores in epss_data.items()
+                    if scores.get("epss_score", 0) > 0.5 and cve_id not in kev_set
                 ),
-                'kev_with_low_epss': sum(
-                    1 for cve_id in kev_set
-                    if cve_id in epss_data and epss_data[cve_id].get('epss_score', 0) < 0.1
-                )
-            }
+                "kev_with_low_epss": sum(
+                    1 for cve_id in kev_set if cve_id in epss_data and epss_data[cve_id].get("epss_score", 0) < 0.1
+                ),
+            },
         }
-        
-        output_file = self.output_dir / 'scoring_comparison.json'
-        with open(output_file, 'w') as f:
+
+        output_file = self.output_dir / "scoring_comparison.json"
+        with open(output_file, "w") as f:
             json.dump(comparison, f, indent=2)
-        
+
         logger.info(f"  ✅ Generated {output_file.name}")
         logger.info(f"     EPSS ∩ KEV: {epss_and_kev:,}")
-        
+
         return comparison
-    
+
     def generate_all(self) -> dict[str, Any]:
         """Generate all scoring analysis files"""
         logger.info("\n📊 Generating Scoring Hub Analysis Files")
         logger.info("=" * 50)
-        
+
         results = {}
-        results['epss'] = self.generate_epss_analysis()
-        results['kev'] = self.generate_kev_analysis()
-        results['risk_matrix'] = self.generate_risk_matrix()
-        results['comparison'] = self.generate_scoring_comparison()
-        
+        results["epss"] = self.generate_epss_analysis()
+        results["kev"] = self.generate_kev_analysis()
+        results["risk_matrix"] = self.generate_risk_matrix()
+        results["comparison"] = self.generate_scoring_comparison()
+
         logger.info("=" * 50)
         logger.info("✅ All scoring analysis files generated!")
-        
+
         return results
-    
+
     def generate_all_scoring_analysis(self) -> dict[str, Any]:
         """Alias for generate_all() - used by build.py"""
         return self.generate_all()
@@ -616,5 +603,5 @@ def main() -> None:
     analyzer.generate_all()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/data/scoring_analysis.py
+++ b/data/scoring_analysis.py
@@ -139,7 +139,7 @@ class ScoringAnalyzer:
                         count += 1
             else:
                 # Old format: dict keyed by CVE ID
-                for cve_id, cve_data in nvd_data.items():
+                for cve_data in nvd_data.values():
                     if cve_data.get("cvss_v3") or cve_data.get("cvss_v2"):
                         count += 1
 

--- a/data/scoring_analysis.py
+++ b/data/scoring_analysis.py
@@ -16,8 +16,8 @@ from typing import Any
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/cna_mapping_restart.py
+++ b/data/scripts/cna_mapping_restart.py
@@ -68,7 +68,7 @@ with open(cache_dir / "cna_list.json") as f:
     cna_list = cna_list_raw["data"] if isinstance(cna_list_raw, dict) and "data" in cna_list_raw else cna_list_raw
 
 # Build official CNA lookup by UUID and normalized name
-uuid_to_name = {uuid: name for uuid, name in uuid_map.items()}
+uuid_to_name = dict(uuid_map)
 official_names = {normalize_name(name): uuid for uuid, name in uuid_map.items()}
 # Build contact email and domain lookup from cna_list.json
 email_to_cna = {}

--- a/data/scripts/cna_mapping_restart.py
+++ b/data/scripts/cna_mapping_restart.py
@@ -15,9 +15,10 @@ Maps every CVE to either an official or unofficial CNA using:
 import json
 import re
 import sys
-from pathlib import Path
 from collections import defaultdict
 from datetime import datetime
+from pathlib import Path
+
 
 # Logging setup, matching the sibling rebuild scripts.
 try:
@@ -29,39 +30,42 @@ logger = get_logger(__name__)
 
 # Utility: Normalize CNA names for fuzzy matching
 
+
 def normalize_name(name):
     if not name:
-        return ''
+        return ""
     return (
         name.lower()
-        .replace(',', '')
-        .replace('.', '')
-        .replace('incorporated', 'inc')
-        .replace('corporation', 'corp')
-        .replace('limited', 'ltd')
-        .replace('llc', '')
-        .replace('inc', '')
-        .replace('corp', '')
-        .replace('ltd', '')
-        .replace('the ', '')
-        .replace('&', 'and')
-        .replace('  ', ' ')
+        .replace(",", "")
+        .replace(".", "")
+        .replace("incorporated", "inc")
+        .replace("corporation", "corp")
+        .replace("limited", "ltd")
+        .replace("llc", "")
+        .replace("inc", "")
+        .replace("corp", "")
+        .replace("ltd", "")
+        .replace("the ", "")
+        .replace("&", "and")
+        .replace("  ", " ")
         .strip()
     )
+
 
 def extract_designation_year(cna_id):
     match = re.match(r"CNA-(\d{4})-", cna_id or "")
     return int(match.group(1)) if match else None
 
+
 # Load all reference data
-cache_dir = Path(__file__).parent / 'cache'
-with open(cache_dir / 'nvd.json', 'r') as f:
+cache_dir = Path(__file__).parent / "cache"
+with open(cache_dir / "nvd.json") as f:
     cve_data = [json.loads(line) for line in f if line.strip()]
-with open(cache_dir / 'cna_name_map.json', 'r') as f:
+with open(cache_dir / "cna_name_map.json") as f:
     uuid_map = json.load(f)  # uuid: org_name
-with open(cache_dir / 'cna_list.json', 'r') as f:
+with open(cache_dir / "cna_list.json") as f:
     cna_list_raw = json.load(f)
-    cna_list = cna_list_raw['data'] if isinstance(cna_list_raw, dict) and 'data' in cna_list_raw else cna_list_raw
+    cna_list = cna_list_raw["data"] if isinstance(cna_list_raw, dict) and "data" in cna_list_raw else cna_list_raw
 
 # Build official CNA lookup by UUID and normalized name
 uuid_to_name = {uuid: name for uuid, name in uuid_map.items()}
@@ -71,67 +75,77 @@ email_to_cna = {}
 domain_to_cna = {}
 cnaid_to_year = {}
 for cna in cna_list:
-    org_name = cna.get('organizationName', '')
-    cna_id = cna.get('cnaID', '')
+    org_name = cna.get("organizationName", "")
+    cna_id = cna.get("cnaID", "")
     if cna_id:
         cnaid_to_year[org_name] = extract_designation_year(cna_id)
     # Contact emails
-    for contact in cna.get('contact', []):
-        for email in contact.get('email', []):
-            email_addr = email.get('emailAddr', '').lower()
+    for contact in cna.get("contact", []):
+        for email in contact.get("email", []):
+            email_addr = email.get("emailAddr", "").lower()
             if email_addr:
                 email_to_cna[email_addr] = org_name
-                domain = email_addr.split('@')[-1]
+                domain = email_addr.split("@")[-1]
                 if domain:
                     domain_to_cna[domain] = org_name
 
 # Main mapping pass
-cna_stats = defaultdict(lambda: {'count': 0, 'cve_ids': [], 'first_cve_year': None, 'last_cve_year': None, 'designation_year': None, 'official': False, 'source': set()})
+cna_stats = defaultdict(
+    lambda: {
+        "count": 0,
+        "cve_ids": [],
+        "first_cve_year": None,
+        "last_cve_year": None,
+        "designation_year": None,
+        "official": False,
+        "source": set(),
+    }
+)
 unknown_cnas = set()
 for cve in cve_data:
     # 1. Try UUID/official CNA mapping
-    cna_uuid = cve.get('cna', '')
-    cna_name = uuid_to_name.get(cna_uuid, '')
+    cna_uuid = cve.get("cna", "")
+    cna_name = uuid_to_name.get(cna_uuid, "")
     if cna_name:
         mapped_name = cna_name
         official = True
         designation_year = cnaid_to_year.get(cna_name)
-        source = 'uuid'
+        source = "uuid"
     else:
         # 2. Try reporting email(s)
         emails = set()
         # NVD v2: sourceIdentifier or assigner field, and any emails in references
-        assigner = cve.get('assigner', '')
-        if assigner and '@' in assigner:
+        assigner = cve.get("assigner", "")
+        if assigner and "@" in assigner:
             emails.add(assigner.lower())
         # Try references
-        for ref in cve.get('references', []):
-            url = ref.get('url', '')
-            if '@' in url:
+        for ref in cve.get("references", []):
+            url = ref.get("url", "")
+            if "@" in url:
                 emails.add(url.lower())
         # Try description for emails
-        desc = cve.get('description', '')
-        for match in re.findall(r'[\w\.-]+@[\w\.-]+', desc):
+        desc = cve.get("description", "")
+        for match in re.findall(r"[\w\.-]+@[\w\.-]+", desc):
             emails.add(match.lower())
-        mapped_name = ''
+        mapped_name = ""
         official = False
         designation_year = None
-        source = ''
+        source = ""
         for email in emails:
             # Direct email match
             if email in email_to_cna:
                 mapped_name = email_to_cna[email]
                 official = normalize_name(mapped_name) in official_names
                 designation_year = cnaid_to_year.get(mapped_name)
-                source = 'email'
+                source = "email"
                 break
             # Domain match
-            domain = email.split('@')[-1]
+            domain = email.split("@")[-1]
             if domain in domain_to_cna:
                 mapped_name = domain_to_cna[domain]
                 official = normalize_name(mapped_name) in official_names
                 designation_year = cnaid_to_year.get(mapped_name)
-                source = 'domain'
+                source = "domain"
                 break
         # 3. Fallback: fuzzy name from assigner
         if not mapped_name and assigner:
@@ -140,51 +154,53 @@ for cve in cve_data:
                 mapped_name = uuid_to_name[official_names[normalized]]
                 official = True
                 designation_year = cnaid_to_year.get(mapped_name)
-                source = 'fuzzy-assigner'
+                source = "fuzzy-assigner"
         # 4. Edge: fallback to email or domain as "Unofficial CNA"
         if not mapped_name and emails:
             mapped_name = sorted(emails)[0]  # Use first email as CNA name
             official = False
             designation_year = None
-            source = 'unofficial-email'
+            source = "unofficial-email"
         if not mapped_name:
-            mapped_name = 'Unknown CNA'
+            mapped_name = "Unknown CNA"
             official = False
             designation_year = None
-            source = 'unknown'
+            source = "unknown"
     # Update stats
-    cna_stats[mapped_name]['count'] += 1
-    cna_stats[mapped_name]['cve_ids'].append(cve.get('id', ''))
-    year = int(cve.get('published', '1970')[:4]) if 'published' in cve else None
+    cna_stats[mapped_name]["count"] += 1
+    cna_stats[mapped_name]["cve_ids"].append(cve.get("id", ""))
+    year = int(cve.get("published", "1970")[:4]) if "published" in cve else None
     if year:
-        if not cna_stats[mapped_name]['first_cve_year'] or year < cna_stats[mapped_name]['first_cve_year']:
-            cna_stats[mapped_name]['first_cve_year'] = year
-        if not cna_stats[mapped_name]['last_cve_year'] or year > cna_stats[mapped_name]['last_cve_year']:
-            cna_stats[mapped_name]['last_cve_year'] = year
+        if not cna_stats[mapped_name]["first_cve_year"] or year < cna_stats[mapped_name]["first_cve_year"]:
+            cna_stats[mapped_name]["first_cve_year"] = year
+        if not cna_stats[mapped_name]["last_cve_year"] or year > cna_stats[mapped_name]["last_cve_year"]:
+            cna_stats[mapped_name]["last_cve_year"] = year
     if designation_year:
-        cna_stats[mapped_name]['designation_year'] = designation_year
-    cna_stats[mapped_name]['official'] = official
-    cna_stats[mapped_name]['source'].add(source)
+        cna_stats[mapped_name]["designation_year"] = designation_year
+    cna_stats[mapped_name]["official"] = official
+    cna_stats[mapped_name]["source"].add(source)
 
 # Output summary
 summary = []
 current_year = datetime.now().year
 for name, stats in cna_stats.items():
     years_active = None
-    if stats['designation_year']:
-        years_active = current_year - stats['designation_year']
-    summary.append({
-        'name': name,
-        'count': stats['count'],
-        'official': stats['official'],
-        'years_active': years_active,
-        'first_cve_year': stats['first_cve_year'],
-        'last_cve_year': stats['last_cve_year'],
-        'sources': sorted(stats['source']),
-    })
-summary.sort(key=lambda x: x['count'], reverse=True)
+    if stats["designation_year"]:
+        years_active = current_year - stats["designation_year"]
+    summary.append(
+        {
+            "name": name,
+            "count": stats["count"],
+            "official": stats["official"],
+            "years_active": years_active,
+            "first_cve_year": stats["first_cve_year"],
+            "last_cve_year": stats["last_cve_year"],
+            "sources": sorted(stats["source"]),
+        }
+    )
+summary.sort(key=lambda x: x["count"], reverse=True)
 
-with open('../web/data/cna_analysis_restart.json', 'w') as f:
+with open("../web/data/cna_analysis_restart.json", "w") as f:
     json.dump(summary, f, indent=2)
 
 logger.info(f"CNA mapping complete. {len(summary)} CNAs found. Output: web/data/cna_analysis_restart.json")

--- a/data/scripts/cna_mapping_restart.py
+++ b/data/scripts/cna_mapping_restart.py
@@ -19,6 +19,14 @@ from pathlib import Path
 from collections import defaultdict
 from datetime import datetime
 
+# Logging setup, matching the sibling rebuild scripts.
+try:
+    from data.logging_config import get_logger
+except ImportError:
+    from logging_config import get_logger
+
+logger = get_logger(__name__)
+
 # Utility: Normalize CNA names for fuzzy matching
 
 def normalize_name(name):

--- a/data/scripts/cna_mapping_restart.py
+++ b/data/scripts/cna_mapping_restart.py
@@ -23,8 +23,8 @@ from pathlib import Path
 # Logging setup, matching the sibling rebuild scripts.
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/generate_cna_analysis.py
+++ b/data/scripts/generate_cna_analysis.py
@@ -134,7 +134,6 @@ class ComprehensiveCNAAnalyzer:
                 'kubernetes.io': 'Cloud Native Computing Foundation',
                 'openssl.org': 'OpenSSL Software Foundation',
                 'nginx.org': 'Nginx Inc.',
-                'apache.org': 'Apache Software Foundation',
                 'eclipse.org': 'Eclipse Foundation',
                 'qt.io': 'The Qt Company',
                 'gnome.org': 'GNOME Foundation',

--- a/data/scripts/generate_cna_analysis.py
+++ b/data/scripts/generate_cna_analysis.py
@@ -15,8 +15,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/generate_cna_analysis.py
+++ b/data/scripts/generate_cna_analysis.py
@@ -20,7 +20,10 @@ except ImportError:
 
 logger = get_logger(__name__)
 
-from download_cve_data import CVEDataDownloader
+from download_cve_data import CVEDataDownloader  # noqa: E402 - requires the
+
+
+# sys.path entry added above, so it cannot move to the top of the file.
 
 
 class ComprehensiveCNAAnalyzer:

--- a/data/scripts/generate_cna_analysis.py
+++ b/data/scripts/generate_cna_analysis.py
@@ -6,9 +6,10 @@ Processes all CVE data to generate complete CNA statistics including ALL active 
 
 import json
 import sys
+from collections import Counter, defaultdict
 from datetime import datetime
 from pathlib import Path
-from collections import defaultdict, Counter
+
 
 # Logging setup
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -21,21 +22,22 @@ logger = get_logger(__name__)
 
 from download_cve_data import CVEDataDownloader
 
+
 class ComprehensiveCNAAnalyzer:
     """Generates comprehensive CNA analysis with all active CNAs"""
-    
+
     def __init__(self):
         self.base_dir = Path(__file__).parent
         self.downloader = CVEDataDownloader()
         self.data_file = None
-        
+
         # CNA mapping data for proper name resolution
         self.cna_list = {}
         self.cna_name_map = {}
-        
+
         logger.info("Comprehensive CNA Analyzer Initialized")
         logger.info("Will process ALL CVE data to find every active CNA")
-    
+
     def ensure_data_loaded(self):
         """Ensure CVE data is downloaded and available"""
         if self.data_file is None:
@@ -44,305 +46,307 @@ class ComprehensiveCNAAnalyzer:
             self.data_file = self.downloader.ensure_data_available()
             if not self.quiet:
                 logger.info(f"Data loaded from: {self.data_file}")
-            
+
             # Load CNA mapping data
             self.load_cna_mappings()
-    
+
     def load_cna_mappings(self):
         """Load CNA mapping files for proper name resolution"""
         try:
             # Load CNA list
             cna_list_file = self.downloader.cache_dir / "cna_list.json"
             if cna_list_file.exists():
-                with open(cna_list_file, 'r', encoding='utf-8') as f:
+                with open(cna_list_file, encoding="utf-8") as f:
                     cna_data = json.load(f)
-                    
+
                     # Handle different data structure formats
                     cna_entries = []
-                    if isinstance(cna_data, dict) and 'data' in cna_data:
-                        cna_entries = cna_data['data']
+                    if isinstance(cna_data, dict) and "data" in cna_data:
+                        cna_entries = cna_data["data"]
                     elif isinstance(cna_data, list):
                         cna_entries = cna_data
                     elif isinstance(cna_data, dict):
                         # Sometimes the data is directly in the root
-                        cna_entries = [cna_data] if 'sourceIdentifier' in cna_data else []
-                    
+                        cna_entries = [cna_data] if "sourceIdentifier" in cna_data else []
+
                     # Convert to lookup dict by sourceIdentifier
                     for cna in cna_entries:
                         if isinstance(cna, dict):
-                            source_id = cna.get('sourceIdentifier', '')
+                            source_id = cna.get("sourceIdentifier", "")
                             if source_id:
                                 self.cna_list[source_id] = cna
-                
+
                 logger.info(f"Loaded {len(self.cna_list)} CNA entries")
-            
+
             # Load CNA name mapping
             cna_name_map_file = self.downloader.cache_dir / "cna_name_map.json"
             if cna_name_map_file.exists():
-                with open(cna_name_map_file, 'r', encoding='utf-8') as f:
+                with open(cna_name_map_file, encoding="utf-8") as f:
                     self.cna_name_map = json.load(f)
                 logger.info(f"Loaded CNA name mappings for {len(self.cna_name_map)} entries")
-                
+
         except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
             logger.warning(f"Could not load CNA mappings: {e}")
             logger.info("Will use raw sourceIdentifier values as fallback")
-    
+
     def resolve_cna_name(self, source_identifier):
         """Resolve CNA sourceIdentifier to proper organization name using comprehensive mapping"""
         try:
             # Handle special cases first
-            if source_identifier == '416baaa9-dc9f-4396-8d5f-8c081fb06d67':
-                return 'Linux Kernel Organization'
-            
+            if source_identifier == "416baaa9-dc9f-4396-8d5f-8c081fb06d67":
+                return "Linux Kernel Organization"
+
             # First try the official UUID-based name mapping file (most authoritative)
             if source_identifier in self.cna_name_map:
                 resolved_name = self.cna_name_map[source_identifier]
                 logger.debug(f"Resolved UUID {source_identifier} to: {resolved_name}")
                 return resolved_name
-            
+
             # Create comprehensive domain-to-organization mapping
             domain_mappings = {
-                'mitre.org': 'MITRE Corporation',
-                'oracle.com': 'Oracle Corporation',
-                'adobe.com': 'Adobe Inc.',
-                'redhat.com': 'Red Hat, Inc.',
-                'microsoft.com': 'Microsoft Corporation',
-                'google.com': 'Google LLC',
-                'github.com': 'GitHub, Inc.',
-                'cisco.com': 'Cisco Systems, Inc.',
-                'ibm.com': 'IBM Corporation',
-                'apple.com': 'Apple Inc.',
-                'intel.com': 'Intel Corporation',
-                'mozilla.org': 'Mozilla Foundation',
-                'canonical.com': 'Canonical Ltd.',
-                'debian.org': 'Debian Project',
-                'apache.org': 'Apache Software Foundation',
-                'kernel.org': 'Linux Kernel Organization',
-                'suse.com': 'SUSE LLC',
-                'ubuntu.com': 'Canonical Ltd.',
-                'fedoraproject.org': 'Red Hat, Inc.',
-                'centos.org': 'Red Hat, Inc.',
-                'php.net': 'PHP Group',
-                'python.org': 'Python Software Foundation',
-                'nodejs.org': 'Node.js Foundation',
-                'ruby-lang.org': 'Ruby Association',
-                'perl.org': 'Perl Foundation',
-                'golang.org': 'Google LLC',
-                'rust-lang.org': 'Rust Foundation',
-                'jenkins.io': 'Jenkins Project',
-                'docker.com': 'Docker Inc.',
-                'kubernetes.io': 'Cloud Native Computing Foundation',
-                'openssl.org': 'OpenSSL Software Foundation',
-                'nginx.org': 'Nginx Inc.',
-                'eclipse.org': 'Eclipse Foundation',
-                'qt.io': 'The Qt Company',
-                'gnome.org': 'GNOME Foundation',
-                'kde.org': 'KDE e.V.',
-                'freedesktop.org': 'freedesktop.org',
-                'x.org': 'X.Org Foundation',
-                'videolan.org': 'VideoLAN',
-                'ffmpeg.org': 'FFmpeg Project',
-                'imagemagick.org': 'ImageMagick Studio LLC',
-                'gimp.org': 'GIMP Team',
-                'blender.org': 'Blender Foundation',
-                'libreoffice.org': 'The Document Foundation',
-                'wordpress.org': 'WordPress Foundation',
-                'drupal.org': 'Drupal Association',
-                'joomla.org': 'Open Source Matters',
-                'magento.com': 'Adobe Inc.',
-                'shopify.com': 'Shopify Inc.',
-                'salesforce.com': 'Salesforce.com, Inc.',
-                'atlassian.com': 'Atlassian Corporation',
-                'jetbrains.com': 'JetBrains s.r.o.',
-                'vmware.com': 'VMware, Inc.',
-                'citrix.com': 'Citrix Systems, Inc.',
-                'hp.com': 'HP Inc.',
-                'dell.com': 'Dell Technologies Inc.',
-                'lenovo.com': 'Lenovo Group Limited',
-                'asus.com': 'ASUSTeK Computer Inc.',
-                'acer.com': 'Acer Inc.',
-                'samsung.com': 'Samsung Electronics Co., Ltd.',
-                'lg.com': 'LG Electronics Inc.',
-                'sony.com': 'Sony Corporation',
-                'panasonic.com': 'Panasonic Corporation',
-                'toshiba.com': 'Toshiba Corporation',
-                'fujitsu.com': 'Fujitsu Limited',
-                'hitachi.com': 'Hitachi, Ltd.',
-                'nec.com': 'NEC Corporation',
-                'huawei.com': 'Huawei Technologies Co., Ltd.',
-                'xiaomi.com': 'Xiaomi Inc.',
-                'oppo.com': 'OPPO Electronics Corp.',
-                'vivo.com': 'Vivo Communication Technology Co. Ltd.',
-                'oneplus.com': 'OnePlus Technology (Shenzhen) Co., Ltd.',
-                'realme.com': 'Realme Chongqing Mobile Telecommunications Corp., Ltd.',
-                'qualcomm.com': 'QUALCOMM Incorporated',
-                'mediatek.com': 'MediaTek Inc.',
-                'broadcom.com': 'Broadcom Inc.',
-                'marvell.com': 'Marvell Technology Group Ltd.',
-                'nvidia.com': 'NVIDIA Corporation',
-                'amd.com': 'Advanced Micro Devices, Inc.',
-                'arm.com': 'Arm Limited',
-                'xilinx.com': 'Xilinx, Inc.',
-                'altera.com': 'Intel Corporation',
-                'ti.com': 'Texas Instruments Incorporated',
-                'analog.com': 'Analog Devices, Inc.',
-                'maxim-ic.com': 'Maxim Integrated Products, Inc.',
-                'microchip.com': 'Microchip Technology Inc.',
-                'st.com': 'STMicroelectronics N.V.',
-                'nxp.com': 'NXP Semiconductors N.V.',
-                'infineon.com': 'Infineon Technologies AG',
-                'renesas.com': 'Renesas Electronics Corporation',
-                'rohm.com': 'ROHM Co., Ltd.',
-                'onsemi.com': 'ON Semiconductor Corporation',
-                'cypress.com': 'Cypress Semiconductor Corporation',
-                'lattice.com': 'Lattice Semiconductor Corporation',
-                'microsemi.com': 'Microsemi Corporation',
-                'actel.com': 'Microsemi Corporation',
-                'patchstack.com': 'patchstack.com',
-                'vuldb.com': 'vuldb.com',
-                'wordfence.com': 'wordfence.com',
-                'wpscan.com': 'wpscan.com',
-                'trendmicro.com': 'trendmicro.com',
-                'huntr.dev': 'huntr.dev',
-                'snyk.io': 'snyk.io',
-                'bress.net': 'bress.net',
-                'flexerasoftware.com': 'flexerasoftware.com',
-                'hpe.com': 'hpe.com',
-                'incibe.es': 'incibe.es',
-                'sap.com': 'sap.com',
-                'unisoc.com': 'unisoc.com',
-                'freebsd.org': 'freebsd.org',
-                'netbsd.org': 'NetBSD Foundation',
-                'openbsd.org': 'OpenBSD Project',
-                'dragonflybsd.org': 'DragonFly BSD Project',
-                'gentoo.org': 'Gentoo Foundation',
-                'archlinux.org': 'Arch Linux',
-                'slackware.com': 'Slackware Linux, Inc.',
-                'opensuse.org': 'openSUSE Project',
-                'mandriva.com': 'Mandriva S.A.',
-                'mageia.org': 'Mageia.Org',
-                'pclinuxos.com': 'PCLinuxOS',
-                'puppy.com': 'Puppy Linux',
-                'tinycore.net': 'Tiny Core Linux',
-                'alpinelinux.org': 'Alpine Linux',
-                'voidlinux.org': 'Void Linux',
-                'nixos.org': 'NixOS Foundation',
-                'guix.gnu.org': 'GNU Project'
+                "mitre.org": "MITRE Corporation",
+                "oracle.com": "Oracle Corporation",
+                "adobe.com": "Adobe Inc.",
+                "redhat.com": "Red Hat, Inc.",
+                "microsoft.com": "Microsoft Corporation",
+                "google.com": "Google LLC",
+                "github.com": "GitHub, Inc.",
+                "cisco.com": "Cisco Systems, Inc.",
+                "ibm.com": "IBM Corporation",
+                "apple.com": "Apple Inc.",
+                "intel.com": "Intel Corporation",
+                "mozilla.org": "Mozilla Foundation",
+                "canonical.com": "Canonical Ltd.",
+                "debian.org": "Debian Project",
+                "apache.org": "Apache Software Foundation",
+                "kernel.org": "Linux Kernel Organization",
+                "suse.com": "SUSE LLC",
+                "ubuntu.com": "Canonical Ltd.",
+                "fedoraproject.org": "Red Hat, Inc.",
+                "centos.org": "Red Hat, Inc.",
+                "php.net": "PHP Group",
+                "python.org": "Python Software Foundation",
+                "nodejs.org": "Node.js Foundation",
+                "ruby-lang.org": "Ruby Association",
+                "perl.org": "Perl Foundation",
+                "golang.org": "Google LLC",
+                "rust-lang.org": "Rust Foundation",
+                "jenkins.io": "Jenkins Project",
+                "docker.com": "Docker Inc.",
+                "kubernetes.io": "Cloud Native Computing Foundation",
+                "openssl.org": "OpenSSL Software Foundation",
+                "nginx.org": "Nginx Inc.",
+                "eclipse.org": "Eclipse Foundation",
+                "qt.io": "The Qt Company",
+                "gnome.org": "GNOME Foundation",
+                "kde.org": "KDE e.V.",
+                "freedesktop.org": "freedesktop.org",
+                "x.org": "X.Org Foundation",
+                "videolan.org": "VideoLAN",
+                "ffmpeg.org": "FFmpeg Project",
+                "imagemagick.org": "ImageMagick Studio LLC",
+                "gimp.org": "GIMP Team",
+                "blender.org": "Blender Foundation",
+                "libreoffice.org": "The Document Foundation",
+                "wordpress.org": "WordPress Foundation",
+                "drupal.org": "Drupal Association",
+                "joomla.org": "Open Source Matters",
+                "magento.com": "Adobe Inc.",
+                "shopify.com": "Shopify Inc.",
+                "salesforce.com": "Salesforce.com, Inc.",
+                "atlassian.com": "Atlassian Corporation",
+                "jetbrains.com": "JetBrains s.r.o.",
+                "vmware.com": "VMware, Inc.",
+                "citrix.com": "Citrix Systems, Inc.",
+                "hp.com": "HP Inc.",
+                "dell.com": "Dell Technologies Inc.",
+                "lenovo.com": "Lenovo Group Limited",
+                "asus.com": "ASUSTeK Computer Inc.",
+                "acer.com": "Acer Inc.",
+                "samsung.com": "Samsung Electronics Co., Ltd.",
+                "lg.com": "LG Electronics Inc.",
+                "sony.com": "Sony Corporation",
+                "panasonic.com": "Panasonic Corporation",
+                "toshiba.com": "Toshiba Corporation",
+                "fujitsu.com": "Fujitsu Limited",
+                "hitachi.com": "Hitachi, Ltd.",
+                "nec.com": "NEC Corporation",
+                "huawei.com": "Huawei Technologies Co., Ltd.",
+                "xiaomi.com": "Xiaomi Inc.",
+                "oppo.com": "OPPO Electronics Corp.",
+                "vivo.com": "Vivo Communication Technology Co. Ltd.",
+                "oneplus.com": "OnePlus Technology (Shenzhen) Co., Ltd.",
+                "realme.com": "Realme Chongqing Mobile Telecommunications Corp., Ltd.",
+                "qualcomm.com": "QUALCOMM Incorporated",
+                "mediatek.com": "MediaTek Inc.",
+                "broadcom.com": "Broadcom Inc.",
+                "marvell.com": "Marvell Technology Group Ltd.",
+                "nvidia.com": "NVIDIA Corporation",
+                "amd.com": "Advanced Micro Devices, Inc.",
+                "arm.com": "Arm Limited",
+                "xilinx.com": "Xilinx, Inc.",
+                "altera.com": "Intel Corporation",
+                "ti.com": "Texas Instruments Incorporated",
+                "analog.com": "Analog Devices, Inc.",
+                "maxim-ic.com": "Maxim Integrated Products, Inc.",
+                "microchip.com": "Microchip Technology Inc.",
+                "st.com": "STMicroelectronics N.V.",
+                "nxp.com": "NXP Semiconductors N.V.",
+                "infineon.com": "Infineon Technologies AG",
+                "renesas.com": "Renesas Electronics Corporation",
+                "rohm.com": "ROHM Co., Ltd.",
+                "onsemi.com": "ON Semiconductor Corporation",
+                "cypress.com": "Cypress Semiconductor Corporation",
+                "lattice.com": "Lattice Semiconductor Corporation",
+                "microsemi.com": "Microsemi Corporation",
+                "actel.com": "Microsemi Corporation",
+                "patchstack.com": "patchstack.com",
+                "vuldb.com": "vuldb.com",
+                "wordfence.com": "wordfence.com",
+                "wpscan.com": "wpscan.com",
+                "trendmicro.com": "trendmicro.com",
+                "huntr.dev": "huntr.dev",
+                "snyk.io": "snyk.io",
+                "bress.net": "bress.net",
+                "flexerasoftware.com": "flexerasoftware.com",
+                "hpe.com": "hpe.com",
+                "incibe.es": "incibe.es",
+                "sap.com": "sap.com",
+                "unisoc.com": "unisoc.com",
+                "freebsd.org": "freebsd.org",
+                "netbsd.org": "NetBSD Foundation",
+                "openbsd.org": "OpenBSD Project",
+                "dragonflybsd.org": "DragonFly BSD Project",
+                "gentoo.org": "Gentoo Foundation",
+                "archlinux.org": "Arch Linux",
+                "slackware.com": "Slackware Linux, Inc.",
+                "opensuse.org": "openSUSE Project",
+                "mandriva.com": "Mandriva S.A.",
+                "mageia.org": "Mageia.Org",
+                "pclinuxos.com": "PCLinuxOS",
+                "puppy.com": "Puppy Linux",
+                "tinycore.net": "Tiny Core Linux",
+                "alpinelinux.org": "Alpine Linux",
+                "voidlinux.org": "Void Linux",
+                "nixos.org": "NixOS Foundation",
+                "guix.gnu.org": "GNU Project",
             }
-            
+
             # Try domain mapping for email-like identifiers
-            if '@' in source_identifier:
-                domain = source_identifier.split('@')[-1].lower()
+            if "@" in source_identifier:
+                domain = source_identifier.split("@")[-1].lower()
                 if domain in domain_mappings:
                     return domain_mappings[domain]
                 else:
                     # Return cleaned domain name
                     return domain
-            
+
             # Try direct domain lookup
             if source_identifier.lower() in domain_mappings:
                 return domain_mappings[source_identifier.lower()]
-            
+
             # For other formats, try to extract meaningful name
-            if '.' in source_identifier:
+            if "." in source_identifier:
                 # Looks like a domain
                 domain = source_identifier.lower()
                 if domain in domain_mappings:
                     return domain_mappings[domain]
                 else:
                     return source_identifier
-            
+
             # If it looks like a UUID but wasn't found in mapping, keep as-is for now
-            if len(source_identifier) == 36 and source_identifier.count('-') == 4:
+            if len(source_identifier) == 36 and source_identifier.count("-") == 4:
                 logger.warning(f"UUID {source_identifier} not found in official mapping")
                 return source_identifier
-            
+
             # Return as-is if no mapping found
             return source_identifier
-            
+
         except (KeyError, TypeError, AttributeError) as e:
             logger.warning(f"Error resolving CNA name for '{source_identifier}': {e}")
             return source_identifier
-    
+
     def generate_comprehensive_cna_analysis(self):
         """Generate comprehensive CNA analysis with ALL active CNAs"""
         self.ensure_data_loaded()
-        
+
         logger.info("Generating comprehensive CNA analysis...")
         logger.info("Processing all CVE data to find every active CNA...")
-        
+
         # Track all CNAs and their statistics
-        cna_stats = defaultdict(lambda: {
-            'count': 0,
-            'years_active': set(),
-            'first_cve': None,
-            'last_cve': None,
-            'severity_distribution': Counter(),
-            'cwe_types': Counter()
-        })
-        
+        cna_stats = defaultdict(
+            lambda: {
+                "count": 0,
+                "years_active": set(),
+                "first_cve": None,
+                "last_cve": None,
+                "severity_distribution": Counter(),
+                "cwe_types": Counter(),
+            }
+        )
+
         total_cves_processed = 0
         cves_with_cna = 0
-        
+
         logger.info("Loading JSON array from file...")
         try:
-            with open(self.data_file, 'r', encoding='utf-8') as f:
+            with open(self.data_file, encoding="utf-8") as f:
                 cve_array = json.load(f)
-            
+
             if not isinstance(cve_array, list):
                 raise ValueError(f"Expected JSON array, got {type(cve_array)}")
-            
+
             logger.info(f"Loaded JSON array with {len(cve_array):,} entries")
-            
+
         except (FileNotFoundError, json.JSONDecodeError, ValueError, OSError) as e:
             logger.error(f"Error loading JSON array: {e}")
             return {}
-        
+
         # Process each CVE entry in the array
         for entry_num, cve_data in enumerate(cve_array, 1):
             try:
                 # Skip if data is not a dictionary
                 if not isinstance(cve_data, dict):
                     continue
-                
+
                 # Extract CVE ID with robust error handling
-                cve_id = ''
+                cve_id = ""
                 try:
-                    cve_section = cve_data.get('cve', {})
+                    cve_section = cve_data.get("cve", {})
                     if isinstance(cve_section, dict):
-                        cve_meta = cve_section.get('CVE_data_meta', {})
+                        cve_meta = cve_section.get("CVE_data_meta", {})
                         if isinstance(cve_meta, dict):
-                            cve_id = cve_meta.get('ID', '')
+                            cve_id = cve_meta.get("ID", "")
                 except (AttributeError, TypeError):
                     continue
-                
-                if not cve_id or not cve_id.startswith('CVE-'):
+
+                if not cve_id or not cve_id.startswith("CVE-"):
                     continue
-                
+
                 total_cves_processed += 1
-                
+
                 # Extract CNA information
-                source_identifier = cve_data.get('cve', {}).get('sourceIdentifier', '')
+                source_identifier = cve_data.get("cve", {}).get("sourceIdentifier", "")
                 if source_identifier:
                     cves_with_cna += 1
-                    
+
                     # Resolve CNA name
                     cna_name = self.resolve_cna_name(source_identifier)
-                    
+
                     # Update CNA statistics
-                    cna_stats[cna_name]['count'] += 1
-                    
+                    cna_stats[cna_name]["count"] += 1
+
                     # Extract year from CVE ID or publication date
                     try:
                         # Try to get publication date first
                         pub_date = None
                         date_fields = [
-                            ['publishedDate'],
-                            ['lastModifiedDate'],
-                            ['cve', 'published'],
-                            ['cve', 'lastModified']
+                            ["publishedDate"],
+                            ["lastModifiedDate"],
+                            ["cve", "published"],
+                            ["cve", "lastModified"],
                         ]
-                        
+
                         for field_path in date_fields:
                             try:
                                 value = cve_data
@@ -350,226 +354,227 @@ class ComprehensiveCNAAnalyzer:
                                     value = value[field]
                                 if value:
                                     if isinstance(value, str):
-                                        if 'T' in value:
-                                            pub_date = datetime.fromisoformat(value.replace('Z', '+00:00'))
+                                        if "T" in value:
+                                            pub_date = datetime.fromisoformat(value.replace("Z", "+00:00"))
                                             break
                             except (KeyError, TypeError, ValueError):
                                 continue
-                        
+
                         # Fallback to CVE ID year
                         if not pub_date:
-                            year = int(cve_id.split('-')[1])
+                            year = int(cve_id.split("-")[1])
                             pub_date = datetime(year, 1, 1)
-                        
-                        cna_stats[cna_name]['years_active'].add(pub_date.year)
-                        
+
+                        cna_stats[cna_name]["years_active"].add(pub_date.year)
+
                         # Track first and last CVE dates
-                        if not cna_stats[cna_name]['first_cve'] or pub_date < cna_stats[cna_name]['first_cve']:
-                            cna_stats[cna_name]['first_cve'] = pub_date
-                        if not cna_stats[cna_name]['last_cve'] or pub_date > cna_stats[cna_name]['last_cve']:
-                            cna_stats[cna_name]['last_cve'] = pub_date
-                    
+                        if not cna_stats[cna_name]["first_cve"] or pub_date < cna_stats[cna_name]["first_cve"]:
+                            cna_stats[cna_name]["first_cve"] = pub_date
+                        if not cna_stats[cna_name]["last_cve"] or pub_date > cna_stats[cna_name]["last_cve"]:
+                            cna_stats[cna_name]["last_cve"] = pub_date
+
                     except (ValueError, IndexError):
                         pass
-                    
+
                     # Extract severity information
                     try:
-                        metrics = cve_data.get('cve', {}).get('metrics', {})
-                        severity = 'UNKNOWN'
-                        
+                        metrics = cve_data.get("cve", {}).get("metrics", {})
+                        severity = "UNKNOWN"
+
                         # Try different CVSS versions
-                        for version_key in ['cvssMetricV40', 'cvssMetricV31', 'cvssMetricV30', 'cvssMetricV2']:
+                        for version_key in ["cvssMetricV40", "cvssMetricV31", "cvssMetricV30", "cvssMetricV2"]:
                             if version_key in metrics:
                                 cvss_metrics = metrics[version_key]
                                 if isinstance(cvss_metrics, list) and len(cvss_metrics) > 0:
-                                    if version_key == 'cvssMetricV2':
-                                        severity = cvss_metrics[0].get('baseSeverity', 'UNKNOWN')
+                                    if version_key == "cvssMetricV2":
+                                        severity = cvss_metrics[0].get("baseSeverity", "UNKNOWN")
                                     else:
-                                        cvss_data = cvss_metrics[0].get('cvssData', {})
-                                        severity = cvss_data.get('baseSeverity', 'UNKNOWN')
+                                        cvss_data = cvss_metrics[0].get("cvssData", {})
+                                        severity = cvss_data.get("baseSeverity", "UNKNOWN")
                                     break
-                        
-                        cna_stats[cna_name]['severity_distribution'][severity] += 1
+
+                        cna_stats[cna_name]["severity_distribution"][severity] += 1
                     except (KeyError, TypeError, IndexError):
-                        cna_stats[cna_name]['severity_distribution']['UNKNOWN'] += 1
-                    
+                        cna_stats[cna_name]["severity_distribution"]["UNKNOWN"] += 1
+
                     # Extract CWE information
                     try:
-                        weaknesses = cve_data.get('cve', {}).get('weaknesses', [])
+                        weaknesses = cve_data.get("cve", {}).get("weaknesses", [])
                         for weakness in weaknesses:
-                            descriptions = weakness.get('description', [])
+                            descriptions = weakness.get("description", [])
                             for desc in descriptions:
-                                if desc.get('lang') == 'en':
-                                    cwe_value = desc.get('value', '')
-                                    if cwe_value and cwe_value.startswith('CWE-') and 'Missing_' not in cwe_value:
-                                        cna_stats[cna_name]['cwe_types'][cwe_value] += 1
+                                if desc.get("lang") == "en":
+                                    cwe_value = desc.get("value", "")
+                                    if cwe_value and cwe_value.startswith("CWE-") and "Missing_" not in cwe_value:
+                                        cna_stats[cna_name]["cwe_types"][cwe_value] += 1
                     except (KeyError, TypeError):
                         pass
-                    
+
                 # Progress indicator
                 if entry_num % 10000 == 0 and entry_num > 0 and not self.quiet:
                     logger.debug(f"Processed {entry_num:,} entries, found {len(cna_stats)} unique CNAs so far...")
-            
+
             except (KeyError, ValueError, TypeError):
                 continue
-        
+
         logger.info("Processing complete!")
         logger.info(f"Total CVEs processed: {total_cves_processed:,}")
         logger.info(f"CVEs with CNA information: {cves_with_cna:,}")
         logger.info(f"Unique CNAs found: {len(cna_stats):,}")
-        
+
         # Convert to final format with activity status
         current_date = datetime.now()
         twelve_months_ago = current_date.replace(year=current_date.year - 1)
-        
+
         cna_list = []
         active_cnas = 0
         inactive_cnas = 0
-        
+
         for cna_name, stats in cna_stats.items():
             # Determine activity status based on last CVE publication
-            is_active = stats['last_cve'] and stats['last_cve'] >= twelve_months_ago
+            is_active = stats["last_cve"] and stats["last_cve"] >= twelve_months_ago
             if is_active:
                 active_cnas += 1
             else:
                 inactive_cnas += 1
-            
+
             cna_entry = {
-                'name': cna_name,
-                'count': stats['count'],
-                'years_active': len(stats['years_active']),
-                'first_cve_year': stats['first_cve'].year if stats['first_cve'] else None,
-                'last_cve_year': stats['last_cve'].year if stats['last_cve'] else None,
-                'last_cve_date': stats['last_cve'].isoformat() if stats['last_cve'] else None,
-                'days_since_last_cve': (current_date - stats['last_cve']).days if stats['last_cve'] else None,
-                'activity_status': 'Active' if is_active else 'Inactive',
-                'activity_level': self.categorize_activity_level(stats['count']),
-                'top_severities': dict(stats['severity_distribution'].most_common(3)),
-                'top_cwes': dict(stats['cwe_types'].most_common(5))
+                "name": cna_name,
+                "count": stats["count"],
+                "years_active": len(stats["years_active"]),
+                "first_cve_year": stats["first_cve"].year if stats["first_cve"] else None,
+                "last_cve_year": stats["last_cve"].year if stats["last_cve"] else None,
+                "last_cve_date": stats["last_cve"].isoformat() if stats["last_cve"] else None,
+                "days_since_last_cve": (current_date - stats["last_cve"]).days if stats["last_cve"] else None,
+                "activity_status": "Active" if is_active else "Inactive",
+                "activity_level": self.categorize_activity_level(stats["count"]),
+                "top_severities": dict(stats["severity_distribution"].most_common(3)),
+                "top_cwes": dict(stats["cwe_types"].most_common(5)),
             }
             cna_list.append(cna_entry)
-        
+
         # Sort by CVE count (descending)
-        cna_list.sort(key=lambda x: x['count'], reverse=True)
-        
+        cna_list.sort(key=lambda x: x["count"], reverse=True)
+
         # Generate analysis
-        total_cves = sum(stats['count'] for stats in cna_stats.values())
-        
+        total_cves = sum(stats["count"] for stats in cna_stats.values())
+
         analysis = {
-            'top_cna_assigners_all_time': [
-                {'name': cna['name'], 'count': cna['count']} 
+            "top_cna_assigners_all_time": [{"name": cna["name"], "count": cna["count"]} for cna in cna_list],
+            "active_cna_assigners": [
+                {"name": cna["name"], "count": cna["count"], "last_cve_date": cna["last_cve_date"]}
                 for cna in cna_list
+                if cna["activity_status"] == "Active"
             ],
-            'active_cna_assigners': [
-                {'name': cna['name'], 'count': cna['count'], 'last_cve_date': cna['last_cve_date']} 
-                for cna in cna_list if cna['activity_status'] == 'Active'
-            ],
-            'detailed_cna_stats': cna_list,
-            'summary_statistics': {
-                'total_unique_cnas': len(cna_list),
-                'active_cnas': active_cnas,
-                'inactive_cnas': inactive_cnas,
-                'activity_rate': round(active_cnas / len(cna_list) * 100, 1) if cna_list else 0,
-                'total_cves_assigned': total_cves,
-                'cves_by_active_cnas': sum(cna['count'] for cna in cna_list if cna['activity_status'] == 'Active'),
-                'average_cves_per_cna': round(total_cves / len(cna_list)) if cna_list else 0,
-                'average_cves_per_active_cna': round(sum(cna['count'] for cna in cna_list if cna['activity_status'] == 'Active') / active_cnas) if active_cnas > 0 else 0,
-                'top_10_share': sum(cna['count'] for cna in cna_list[:10]) / total_cves * 100 if total_cves > 0 else 0,
-                'activity_distribution': self.get_activity_distribution(cna_list),
-                'status_distribution': self.get_status_distribution(cna_list),
-                'coverage_years': self.get_coverage_years(cna_list),
-                'activity_threshold_date': twelve_months_ago.isoformat()
+            "detailed_cna_stats": cna_list,
+            "summary_statistics": {
+                "total_unique_cnas": len(cna_list),
+                "active_cnas": active_cnas,
+                "inactive_cnas": inactive_cnas,
+                "activity_rate": round(active_cnas / len(cna_list) * 100, 1) if cna_list else 0,
+                "total_cves_assigned": total_cves,
+                "cves_by_active_cnas": sum(cna["count"] for cna in cna_list if cna["activity_status"] == "Active"),
+                "average_cves_per_cna": round(total_cves / len(cna_list)) if cna_list else 0,
+                "average_cves_per_active_cna": round(
+                    sum(cna["count"] for cna in cna_list if cna["activity_status"] == "Active") / active_cnas
+                )
+                if active_cnas > 0
+                else 0,
+                "top_10_share": sum(cna["count"] for cna in cna_list[:10]) / total_cves * 100 if total_cves > 0 else 0,
+                "activity_distribution": self.get_activity_distribution(cna_list),
+                "status_distribution": self.get_status_distribution(cna_list),
+                "coverage_years": self.get_coverage_years(cna_list),
+                "activity_threshold_date": twelve_months_ago.isoformat(),
             },
-            'processing_stats': {
-                'processed_at': datetime.now().isoformat(),
-                'total_cves_processed': total_cves_processed,
-                'cves_with_cna_info': cves_with_cna,
-                'data_source': 'comprehensive_nvd_jsonl_analysis'
-            }
+            "processing_stats": {
+                "processed_at": datetime.now().isoformat(),
+                "total_cves_processed": total_cves_processed,
+                "cves_with_cna_info": cves_with_cna,
+                "data_source": "comprehensive_nvd_jsonl_analysis",
+            },
         }
-        
+
         return analysis
-    
+
     def categorize_activity_level(self, count):
         """Categorize CNA activity level based on CVE count"""
         if count >= 10000:
-            return 'Very High'
+            return "Very High"
         elif count >= 1000:
-            return 'High'
+            return "High"
         elif count >= 100:
-            return 'Medium'
+            return "Medium"
         elif count >= 10:
-            return 'Low'
+            return "Low"
         else:
-            return 'Minimal'
-    
+            return "Minimal"
+
     def get_activity_distribution(self, cna_list):
         """Get distribution of CNAs by activity level"""
         distribution = Counter()
         for cna in cna_list:
-            distribution[cna['activity_level']] += 1
+            distribution[cna["activity_level"]] += 1
         return dict(distribution)
-    
+
     def get_status_distribution(self, cna_list):
         """Get distribution of CNAs by activity status"""
         distribution = Counter()
         for cna in cna_list:
-            distribution[cna['activity_status']] += 1
+            distribution[cna["activity_status"]] += 1
         return dict(distribution)
-    
+
     def get_coverage_years(self, cna_list):
         """Get coverage years with safe handling of empty data"""
         try:
             # Get all valid first and last CVE years
-            first_years = [cna['first_cve_year'] for cna in cna_list if cna['first_cve_year'] is not None]
-            last_years = [cna['last_cve_year'] for cna in cna_list if cna['last_cve_year'] is not None]
-            
+            first_years = [cna["first_cve_year"] for cna in cna_list if cna["first_cve_year"] is not None]
+            last_years = [cna["last_cve_year"] for cna in cna_list if cna["last_cve_year"] is not None]
+
             if first_years and last_years:
-                return {
-                    'earliest': min(first_years),
-                    'latest': max(last_years)
-                }
+                return {"earliest": min(first_years), "latest": max(last_years)}
             else:
                 # Fallback if no valid years found
                 current_year = datetime.now().year
                 return {
-                    'earliest': 1999,  # CVE program started in 1999
-                    'latest': current_year
+                    "earliest": 1999,  # CVE program started in 1999
+                    "latest": current_year,
                 }
         except (ValueError, TypeError) as e:
             logger.warning(f"Error calculating coverage years: {e}")
             current_year = datetime.now().year
-            return {
-                'earliest': 1999,
-                'latest': current_year
-            }
-    
+            return {"earliest": 1999, "latest": current_year}
+
     def save_analysis(self, analysis, output_file):
         """Save analysis to JSON file"""
         output_path = Path(output_file)
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        with open(output_path, 'w', encoding='utf-8') as f:
+
+        with open(output_path, "w", encoding="utf-8") as f:
             json.dump(analysis, f, indent=2, ensure_ascii=False)
-        
+
         logger.info(f"Comprehensive CNA analysis saved to: {output_path}")
         logger.info(f"Found {analysis['summary_statistics']['total_unique_cnas']:,} unique CNAs")
         logger.info(f"Total CVEs assigned: {analysis['summary_statistics']['total_cves_assigned']:,}")
 
+
 def main():
     """Main entry point"""
     import argparse
-    
+
     parser = argparse.ArgumentParser(description="Generate comprehensive CNA analysis")
-    parser.add_argument('--output', '-o', 
-                       default='../web/data/cna_analysis.json',
-                       help='Output file path (default: ../web/data/cna_analysis.json)')
-    
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="../web/data/cna_analysis.json",
+        help="Output file path (default: ../web/data/cna_analysis.json)",
+    )
+
     args = parser.parse_args()
-    
+
     analyzer = ComprehensiveCNAAnalyzer()
     analysis = analyzer.generate_comprehensive_cna_analysis()
     analyzer.save_analysis(analysis, args.output)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/data/scripts/quick_build.py
+++ b/data/scripts/quick_build.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import jinja2
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 class CVEQuickBuilder:

--- a/data/scripts/quick_build.py
+++ b/data/scripts/quick_build.py
@@ -3,6 +3,7 @@
 CVE.ICU Quick Template Builder
 Fast template-only rebuild for development - skips data processing
 """
+
 from __future__ import annotations
 
 import shutil
@@ -13,51 +14,51 @@ from typing import Any
 import jinja2
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
+
 class CVEQuickBuilder:
     """Fast template-only builder for development"""
-    
+
     def __init__(self) -> None:
         self.current_year: int = datetime.now().year
         self.available_years: list[int] = list(range(1999, self.current_year + 1))
         # Go up two levels: scripts -> data -> project root
         self.project_root = Path(__file__).parent.parent.parent
-        self.templates_dir = self.project_root / 'templates'
-        self.web_dir = self.project_root / 'web'
-        self.static_dir = self.web_dir / 'static'
-        self.data_dir = self.web_dir / 'data'
-        
+        self.templates_dir = self.project_root / "templates"
+        self.web_dir = self.project_root / "web"
+        self.static_dir = self.web_dir / "static"
+        self.data_dir = self.web_dir / "data"
+
         # Set up Jinja2 environment
         self.jinja_env = Environment(
-            loader=FileSystemLoader(self.templates_dir),
-            autoescape=select_autoescape(['html', 'xml'])
+            loader=FileSystemLoader(self.templates_dir), autoescape=select_autoescape(["html", "xml"])
         )
-        
+
         # Add custom filters and globals
-        self.jinja_env.globals['current_year'] = self.current_year
-        self.jinja_env.globals['available_years'] = self.available_years
-        self.jinja_env.filters['format_number'] = self.format_number
-        
-        print(f"⚡ CVE.ICU Quick Template Builder")
+        self.jinja_env.globals["current_year"] = self.current_year
+        self.jinja_env.globals["available_years"] = self.available_years
+        self.jinja_env.filters["format_number"] = self.format_number
+
+        print("⚡ CVE.ICU Quick Template Builder")
         print(f"📅 Current Year: {self.current_year}")
         print(f"📂 Templates: {self.templates_dir}")
         print(f"🌐 Web output: {self.web_dir}")
-    
+
     def format_number(self, num: Any) -> str:
         """Format numbers with commas"""
         if isinstance(num, (int, float)):
             return f"{num:,}"
         return str(num)
-    
+
     def copy_static_assets(self) -> None:
         """Copy static assets (CSS, JS, images) if they don't exist"""
         print("📁 Checking static assets...")
-        
+
         # Only copy if static directory doesn't exist or is empty
         if not self.static_dir.exists() or not any(self.static_dir.iterdir()):
             print("  📁 Copying static assets...")
-            
+
             # Copy from project root static if it exists
-            template_static = self.project_root / 'static'
+            template_static = self.project_root / "static"
             if template_static.exists():
                 if self.static_dir.exists():
                     shutil.rmtree(self.static_dir)
@@ -67,87 +68,91 @@ class CVEQuickBuilder:
                 print("  ⚠️  No static assets found to copy")
         else:
             print("  ✅ Static assets already exist")
-    
+
     def generate_html_pages(self) -> None:
         """Generate HTML pages from templates"""
         print("📄 Generating HTML pages...")
-        
+
         # Define pages to generate
         pages = [
-            ('index.html', 'CVE.ICU - Vulnerability Intelligence Platform'),
-            ('years.html', 'Yearly Analysis - CVE.ICU'),
-            ('cna-hub.html', 'CNA Intelligence Hub - CVE.ICU'),
-            ('cna.html', 'CNA Analysis - CVE.ICU'),
-            ('cpe.html', 'CPE Analysis - CVE.ICU'),
-            ('cvss.html', 'CVSS Analysis - CVE.ICU'),
-            ('cwe.html', 'CWE Analysis - CVE.ICU'),
-            ('calendar.html', 'Calendar View - CVE.ICU'),
-            ('growth.html', 'Growth Trends - CVE.ICU'),
-            ('about.html', 'About CVE.ICU - Vulnerability Intelligence Platform'),
-            ('scoring.html', 'Scoring Hub - CVE.ICU'),
-            ('epss.html', 'EPSS Analysis - CVE.ICU'),
-            ('kev.html', 'KEV Dashboard - CVE.ICU'),
-            ('data-quality.html', 'CNA Name Matching - CVE.ICU'),
+            ("index.html", "CVE.ICU - Vulnerability Intelligence Platform"),
+            ("years.html", "Yearly Analysis - CVE.ICU"),
+            ("cna-hub.html", "CNA Intelligence Hub - CVE.ICU"),
+            ("cna.html", "CNA Analysis - CVE.ICU"),
+            ("cpe.html", "CPE Analysis - CVE.ICU"),
+            ("cvss.html", "CVSS Analysis - CVE.ICU"),
+            ("cwe.html", "CWE Analysis - CVE.ICU"),
+            ("calendar.html", "Calendar View - CVE.ICU"),
+            ("growth.html", "Growth Trends - CVE.ICU"),
+            ("about.html", "About CVE.ICU - Vulnerability Intelligence Platform"),
+            ("scoring.html", "Scoring Hub - CVE.ICU"),
+            ("epss.html", "EPSS Analysis - CVE.ICU"),
+            ("kev.html", "KEV Dashboard - CVE.ICU"),
+            ("data-quality.html", "CNA Name Matching - CVE.ICU"),
         ]
-        
+
         for template_name, title in pages:
             try:
                 template = self.jinja_env.get_template(template_name)
-                
+
                 # Basic context for all pages
                 context = {
-                    'title': title,
-                    'current_year': self.current_year,
-                    'available_years': self.available_years,
+                    "title": title,
+                    "current_year": self.current_year,
+                    "available_years": self.available_years,
                 }
-                
+
                 # Add page-specific context
-                if template_name == 'cna.html':
-                    context.update({
-                        'cna_data': [],  # Empty for now - will be populated by JavaScript
-                        'total_cna_cves': 0,
-                        'active_cnas': 0,
-                        'avg_cves_per_cna': 0,
-                    })
-                
+                if template_name == "cna.html":
+                    context.update(
+                        {
+                            "cna_data": [],  # Empty for now - will be populated by JavaScript
+                            "total_cna_cves": 0,
+                            "active_cnas": 0,
+                            "avg_cves_per_cna": 0,
+                        }
+                    )
+
                 html_content = template.render(**context)
-                
+
                 output_path = self.web_dir / template_name
-                with open(output_path, 'w', encoding='utf-8') as f:
+                with open(output_path, "w", encoding="utf-8") as f:
                     f.write(html_content)
-                
+
                 print(f"  📄 Generated {template_name}")
-                
+
             except (jinja2.TemplateError, OSError) as e:
                 print(f"  ❌ Error generating {template_name}: {e}")
                 continue
-        
+
         print("✅ HTML pages generated successfully")
-    
+
     def build(self) -> None:
         """Main build method - templates only"""
         print("\n🏗️  Starting quick template build...")
         print("=" * 50)
-        
+
         # Ensure web directory exists
         self.web_dir.mkdir(exist_ok=True)
-        
+
         # Copy static assets if needed
         self.copy_static_assets()
-        
+
         # Generate HTML pages
         self.generate_html_pages()
-        
+
         print("\n" + "=" * 50)
         print("✅ Quick build completed!")
         print(f"📁 Site ready in: {self.web_dir}")
         print("🌐 Templates updated - data files unchanged")
         print("⚡ Build time: ~1 second vs ~5 minutes")
 
+
 def main() -> None:
     """Main entry point"""
     builder = CVEQuickBuilder()
     builder.build()
+
 
 if __name__ == "__main__":
     main()

--- a/data/scripts/rebuild_cna.py
+++ b/data/scripts/rebuild_cna.py
@@ -3,17 +3,20 @@
 CNA Analysis Rebuild Script
 Quick rebuild script for CNA analysis only - much faster than full site rebuild
 """
+
 from __future__ import annotations
 
 import json
 import sys
 from pathlib import Path
 
+
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cve_v5_processor import CVEV5Processor
-from scripts.utils import setup_paths, print_header
+from scripts.utils import print_header, setup_paths
+
 
 # Logging setup
 try:
@@ -27,22 +30,22 @@ logger = get_logger(__name__)
 def main() -> bool:
     """Rebuild CNA analysis only"""
     print_header("CNA Analysis Quick Rebuild", "🏢")
-    
+
     # Set up paths
     project_root, cache_dir, data_dir = setup_paths()
-    
+
     # Initialize CVE V5 processor
     v5_processor = CVEV5Processor(project_root, cache_dir, data_dir)
-    
+
     try:
         # Generate comprehensive CNA analysis using CVE V5 data
         logger.info("Generating comprehensive CNA analysis (CVE V5 authoritative)...")
         cna_analysis = v5_processor.generate_comprehensive_cna_analysis()
-        
+
         # Generate current year CNA analysis with new publication date logic
         logger.info(f"Generating {v5_processor.current_year} CNA analysis (by publication date)...")
         current_cna_analysis = v5_processor.generate_current_year_analysis()
-        
+
         logger.info("=" * 40)
         logger.info("CNA analysis rebuild completed!")
         logger.info(f"Total CNAs: {cna_analysis.get('total_cnas', 0)}")
@@ -51,16 +54,17 @@ def main() -> bool:
         logger.info("Files updated:")
         logger.info("   - web/data/cna_analysis.json")
         logger.info("   - web/data/cna_analysis_current_year.json")
-        
+
         return True
-        
+
     except (ImportError, json.JSONDecodeError, OSError) as e:
         logger.error(f"CNA analysis rebuild failed: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     success = main()
     sys.exit(0 if success else 1)

--- a/data/scripts/rebuild_cna.py
+++ b/data/scripts/rebuild_cna.py
@@ -5,6 +5,7 @@ Quick rebuild script for CNA analysis only - much faster than full site rebuild
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 

--- a/data/scripts/rebuild_cna.py
+++ b/data/scripts/rebuild_cna.py
@@ -21,8 +21,8 @@ from scripts.utils import print_header, setup_paths
 # Logging setup
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/rebuild_cpe.py
+++ b/data/scripts/rebuild_cpe.py
@@ -3,6 +3,7 @@
 CPE Analysis Rebuild Script
 Quick rebuild script for CPE analysis only - much faster than full site rebuild
 """
+
 from __future__ import annotations
 
 import json
@@ -12,11 +13,13 @@ from pathlib import Path
 
 import jinja2
 
+
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cpe_analysis import CPEAnalyzer
-from scripts.utils import setup_paths, load_all_year_data, print_header
+from scripts.utils import load_all_year_data, print_header, setup_paths
+
 
 # Logging setup
 try:
@@ -30,93 +33,95 @@ logger = get_logger(__name__)
 def main() -> bool:
     """Main rebuild function"""
     print_header("CPE Analysis Quick Rebuild", "🔍")
-    
+
     # Setup paths
     project_root, cache_dir, data_dir = setup_paths()
-    
+
     # Initialize CPE analyzer
     logger.info("Initializing CPE analyzer...")
     cpe_analyzer = CPEAnalyzer(project_root, cache_dir, data_dir)
-    
+
     # Load existing year data for context (if available)
     logger.info("Loading existing year data...")
     all_year_data = load_all_year_data(data_dir)
-    
+
     if all_year_data:
         logger.info(f"Loaded {len(all_year_data)} existing year data files")
     else:
         logger.warning("No existing year data found - CPE analysis will use raw data only")
-    
+
     # Generate comprehensive CPE analysis
     logger.info("Generating comprehensive CPE analysis...")
     try:
         cpe_analysis = cpe_analyzer.generate_cpe_analysis(all_year_data)
-        
-        if cpe_analysis and cpe_analysis.get('total_unique_cpes', 0) > 0:
+
+        if cpe_analysis and cpe_analysis.get("total_unique_cpes", 0) > 0:
             logger.info(f"Generated comprehensive CPE analysis with {cpe_analysis['total_unique_cpes']:,} unique CPEs")
             logger.info(f"Covers {cpe_analysis['total_cves_with_cpes']:,} CVEs with CPE data")
             logger.info(f"Includes {cpe_analysis['total_unique_vendors']:,} unique vendors")
         else:
             logger.error("CPE analysis failed or returned no data")
             return 1
-    
+
     except (ImportError, json.JSONDecodeError, OSError) as e:
         logger.error(f"Error generating comprehensive CPE analysis: {e}")
         import traceback
+
         traceback.print_exc()
         return 1
-    
+
     # Generate current year CPE analysis
     logger.info("Generating current year CPE analysis...")
     try:
         current_year = datetime.now().year
-        current_year_data = next((data for data in all_year_data if data.get('year') == current_year), {})
-        
+        current_year_data = next((data for data in all_year_data if data.get("year") == current_year), {})
+
         current_cpe_analysis = cpe_analyzer.generate_current_year_cpe_analysis(current_year_data)
-        
-        if current_cpe_analysis and current_cpe_analysis.get('total_unique_cpes', 0) > 0:
-            logger.info(f"Generated current year CPE analysis with {current_cpe_analysis['total_unique_cpes']:,} unique CPEs")
+
+        if current_cpe_analysis and current_cpe_analysis.get("total_unique_cpes", 0) > 0:
+            logger.info(
+                f"Generated current year CPE analysis with {current_cpe_analysis['total_unique_cpes']:,} unique CPEs"
+            )
             logger.info(f"Covers {current_cpe_analysis['total_cves_with_cpes']:,} CVEs for {current_year}")
         else:
             logger.warning(f"Current year CPE analysis returned minimal data for {current_year}")
-    
+
     except (ImportError, json.JSONDecodeError, OSError, KeyError) as e:
         logger.error(f"Error generating current year CPE analysis: {e}")
         import traceback
+
         traceback.print_exc()
         logger.warning("Current year analysis will be missing")
-    
+
     # Generate CPE page HTML
     logger.info("Generating CPE page HTML...")
     try:
         from jinja2 import Environment, FileSystemLoader
-        
+
         # Setup Jinja2 environment
-        template_dir = project_root / 'templates'
+        template_dir = project_root / "templates"
         env = Environment(loader=FileSystemLoader(template_dir))
-        
+
         # Load CPE template
-        template = env.get_template('cpe.html')
-        
+        template = env.get_template("cpe.html")
+
         # Render CPE page
-        html_content = template.render(
-            title="CPE Analysis - CVE.ICU",
-            current_year=datetime.now().year
-        )
-        
+        html_content = template.render(title="CPE Analysis - CVE.ICU", current_year=datetime.now().year)
+
         # Save CPE page
-        output_file = project_root / 'web' / 'cpe.html'
-        with open(output_file, 'w', encoding='utf-8') as f:
+        output_file = project_root / "web" / "cpe.html"
+        with open(output_file, "w", encoding="utf-8") as f:
             f.write(html_content)
-        
+
         logger.info(f"Generated CPE page: {output_file}")
-    
+
     except (ImportError, OSError, jinja2.TemplateError) as e:
         logger.error(f"Error generating CPE page HTML: {e}")
         import traceback
+
         traceback.print_exc()
         logger.warning("CPE page HTML generation failed")
-    
+
     logger.info("=" * 50)
     logger.info("CPE Analysis Rebuild Complete!")
     logger.info("Files generated:")
@@ -124,8 +129,9 @@ def main() -> bool:
     logger.info(f"  {data_dir}/cpe_analysis_current_year.json")
     logger.info(f"  {project_root}/web/cpe.html")
     logger.info("You can now view the CPE analysis page in your browser.")
-    
+
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/data/scripts/rebuild_cpe.py
+++ b/data/scripts/rebuild_cpe.py
@@ -24,8 +24,8 @@ from scripts.utils import load_all_year_data, print_header, setup_paths
 # Logging setup
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/rebuild_cvss.py
+++ b/data/scripts/rebuild_cvss.py
@@ -3,6 +3,7 @@
 CVSS Analysis Rebuild Script
 Quick rebuild script for CVSS analysis only - much faster than full site rebuild
 """
+
 from __future__ import annotations
 
 import json
@@ -10,11 +11,13 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cvss_analysis import CVSSAnalyzer
-from scripts.utils import setup_paths, load_all_year_data, print_header
+from scripts.utils import load_all_year_data, print_header, setup_paths
+
 
 # Logging setup
 try:
@@ -28,38 +31,38 @@ logger = get_logger(__name__)
 def main() -> bool:
     """Rebuild CVSS analysis only"""
     print_header("CVSS Analysis Quick Rebuild", "📊")
-    
+
     # Set up paths
     project_root, cache_dir, data_dir = setup_paths()
-    
+
     # Initialize CVSS analyzer
     cvss_analyzer = CVSSAnalyzer(project_root, cache_dir, data_dir)
-    
+
     try:
         # Load existing year data
         logger.info("Loading existing year data...")
         all_year_data = load_all_year_data(data_dir)
         logger.info(f"Loaded {len(all_year_data)} year data files")
-        
+
         if not all_year_data:
             logger.error("No year data found. Run full build first.")
             return False
-        
+
         # Generate comprehensive CVSS analysis
         logger.info("Generating comprehensive CVSS analysis...")
         cvss_analysis = cvss_analyzer.generate_cvss_analysis(all_year_data)
-        
+
         # Generate current year CVSS analysis
         current_year = datetime.now().year
-        current_year_data = next((year for year in all_year_data if year['year'] == current_year), {})
-        
+        current_year_data = next((year for year in all_year_data if year["year"] == current_year), {})
+
         if current_year_data:
             logger.info(f"Generating {current_year} CVSS analysis...")
             current_cvss_analysis = cvss_analyzer.generate_current_year_cvss_analysis(current_year_data)
         else:
             logger.warning(f"No {current_year} data found for current year analysis")
             current_cvss_analysis = {}
-        
+
         logger.info("=" * 40)
         logger.info("CVSS analysis rebuild completed!")
         logger.info(f"Total CVEs with CVSS: {cvss_analysis.get('total_cves_with_cvss', 0):,}")
@@ -71,16 +74,17 @@ def main() -> bool:
         logger.info("   - web/data/cvss_analysis.json")
         if current_cvss_analysis:
             logger.info("   - web/data/cvss_analysis_current_year.json")
-        
+
         return True
-        
+
     except (ImportError, json.JSONDecodeError, OSError) as e:
         logger.error(f"CVSS analysis rebuild failed: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     success = main()
     sys.exit(0 if success else 1)

--- a/data/scripts/rebuild_cvss.py
+++ b/data/scripts/rebuild_cvss.py
@@ -5,6 +5,7 @@ Quick rebuild script for CVSS analysis only - much faster than full site rebuild
 """
 from __future__ import annotations
 
+import json
 import sys
 from datetime import datetime
 from pathlib import Path

--- a/data/scripts/rebuild_cvss.py
+++ b/data/scripts/rebuild_cvss.py
@@ -22,8 +22,8 @@ from scripts.utils import load_all_year_data, print_header, setup_paths
 # Logging setup
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/rebuild_cwe.py
+++ b/data/scripts/rebuild_cwe.py
@@ -5,6 +5,7 @@ Quick rebuild script for CWE analysis only - much faster than full site rebuild
 """
 from __future__ import annotations
 
+import json
 import sys
 from datetime import datetime
 from pathlib import Path

--- a/data/scripts/rebuild_cwe.py
+++ b/data/scripts/rebuild_cwe.py
@@ -3,6 +3,7 @@
 CWE Analysis Rebuild Script
 Quick rebuild script for CWE analysis only - much faster than full site rebuild
 """
+
 from __future__ import annotations
 
 import json
@@ -10,11 +11,13 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from cwe_analysis import CWEAnalyzer
-from scripts.utils import setup_paths, load_all_year_data, print_header
+from scripts.utils import load_all_year_data, print_header, setup_paths
+
 
 # Logging setup
 try:
@@ -28,38 +31,38 @@ logger = get_logger(__name__)
 def main() -> bool:
     """Rebuild CWE analysis only"""
     print_header("CWE Analysis Quick Rebuild", "🔍")
-    
+
     # Set up paths
     project_root, cache_dir, data_dir = setup_paths()
-    
+
     # Initialize CWE analyzer
     cwe_analyzer = CWEAnalyzer(project_root, cache_dir, data_dir)
-    
+
     try:
         # Load existing year data
         logger.info("Loading existing year data...")
         all_year_data = load_all_year_data(data_dir)
         logger.info(f"Loaded {len(all_year_data)} year data files")
-        
+
         if not all_year_data:
             logger.error("No year data found. Run full build first.")
             return False
-        
+
         # Generate comprehensive CWE analysis
         logger.info("Generating comprehensive CWE analysis...")
         cwe_analysis = cwe_analyzer.generate_cwe_analysis(all_year_data)
-        
+
         # Generate current year CWE analysis
         current_year = datetime.now().year
-        current_year_data = next((year for year in all_year_data if year['year'] == current_year), {})
-        
+        current_year_data = next((year for year in all_year_data if year["year"] == current_year), {})
+
         if current_year_data:
             logger.info(f"Generating {current_year} CWE analysis...")
             current_cwe_analysis = cwe_analyzer.generate_current_year_cwe_analysis(current_year_data)
         else:
             logger.warning(f"No {current_year} data found for current year analysis")
             current_cwe_analysis = {}
-        
+
         logger.info("=" * 40)
         logger.info("CWE analysis rebuild completed!")
         logger.info(f"Total CVEs with CWE: {cwe_analysis.get('total_cves_with_cwe', 0):,}")
@@ -69,16 +72,17 @@ def main() -> bool:
         logger.info("   - web/data/cwe_analysis.json")
         if current_cwe_analysis:
             logger.info("   - web/data/cwe_analysis_current_year.json")
-        
+
         return True
-        
+
     except (ImportError, json.JSONDecodeError, OSError) as e:
         logger.error(f"CWE analysis rebuild failed: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     success = main()
     sys.exit(0 if success else 1)

--- a/data/scripts/rebuild_cwe.py
+++ b/data/scripts/rebuild_cwe.py
@@ -22,8 +22,8 @@ from scripts.utils import load_all_year_data, print_header, setup_paths
 # Logging setup
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/rebuild_data_quality.py
+++ b/data/scripts/rebuild_data_quality.py
@@ -30,8 +30,8 @@ sys.path.insert(0, str(DATA_DIR))
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/rebuild_data_quality.py
+++ b/data/scripts/rebuild_data_quality.py
@@ -13,6 +13,7 @@ Matching strategies (in order):
 3. Normalized match (remove spaces, hyphens, underscores)
 4. Partial match (substring containment)
 """
+
 from __future__ import annotations
 
 import json
@@ -20,6 +21,7 @@ import os
 import sys
 from pathlib import Path
 from typing import Any
+
 
 # Logging setup
 SCRIPT_DIR = Path(__file__).parent
@@ -40,13 +42,13 @@ CACHE_DIR = DATA_DIR / "cache"
 
 def load_json(filepath: Path | str) -> Any:
     """Load JSON file."""
-    with open(filepath, 'r', encoding='utf-8') as f:
+    with open(filepath, encoding="utf-8") as f:
         return json.load(f)
 
 
 def save_json(filepath: Path | str, data: Any) -> None:
     """Save JSON file."""
-    with open(filepath, 'w', encoding='utf-8') as f:
+    with open(filepath, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
 
@@ -54,16 +56,18 @@ def normalize_name(name: str) -> str:
     """Normalize a name by removing spaces, hyphens, underscores and lowercasing."""
     if not name:
         return ""
-    return name.lower().replace(' ', '').replace('-', '').replace('_', '').replace('.', '')
+    return name.lower().replace(" ", "").replace("-", "").replace("_", "").replace(".", "")
 
 
-def build_official_cna_lookups(cna_list: list[dict[str, Any]]) -> tuple[dict[str, dict], dict[str, dict], set[str], dict[str, dict]]:
+def build_official_cna_lookups(
+    cna_list: list[dict[str, Any]],
+) -> tuple[dict[str, dict], dict[str, dict], set[str], dict[str, dict]]:
     """
     Build lookup dictionaries for official CNAs.
-    
+
     Returns:
         - short_name_map: shortName -> official entry
-        - org_name_map: organizationName -> official entry  
+        - org_name_map: organizationName -> official entry
         - all_official_names: set of all names (short + org)
         - normalized_map: normalized_name -> official entry
     """
@@ -71,33 +75,33 @@ def build_official_cna_lookups(cna_list: list[dict[str, Any]]) -> tuple[dict[str
     org_name_map = {}
     all_official_names = set()
     normalized_map = {}
-    
+
     for cna in cna_list:
-        short_name = cna.get('shortName', '')
-        org_name = cna.get('organizationName', '')
-        
+        short_name = cna.get("shortName", "")
+        org_name = cna.get("organizationName", "")
+
         if short_name:
             short_name_map[short_name] = cna
             short_name_map[short_name.lower()] = cna  # Also store lowercase
             all_official_names.add(short_name)
             all_official_names.add(short_name.lower())
-            
+
             # Normalized version
             norm = normalize_name(short_name)
             if norm:
                 normalized_map[norm] = cna
-        
+
         if org_name:
             org_name_map[org_name] = cna
             org_name_map[org_name.lower()] = cna
             all_official_names.add(org_name)
             all_official_names.add(org_name.lower())
-            
+
             # Normalized version
             norm = normalize_name(org_name)
             if norm:
                 normalized_map[norm] = cna
-    
+
     return short_name_map, org_name_map, all_official_names, normalized_map
 
 
@@ -106,11 +110,11 @@ def map_cve_name_to_official(
     short_name_map: dict[str, dict],
     org_name_map: dict[str, dict],
     normalized_map: dict[str, dict],
-    cna_list: list[dict[str, Any]]
+    cna_list: list[dict[str, Any]],
 ) -> tuple[dict | None, str | None, str | None]:
     """
     Attempt to match a CVE CNA name to an official CNA entry.
-    
+
     Matching strategies (in order of preference):
     1. Exact match on shortName
     2. Case-insensitive match on shortName
@@ -118,7 +122,7 @@ def map_cve_name_to_official(
     4. Case-insensitive match on organizationName
     5. Normalized match (remove spaces, hyphens, underscores)
     6. Partial match (substring containment with min length)
-    
+
     Returns:
         tuple: (matched_official_entry or None, match_type, confidence)
         match_type: 'exact_short', 'case_short', 'exact_org', 'case_org', 'normalized', 'partial', None
@@ -126,179 +130,184 @@ def map_cve_name_to_official(
     """
     if not cve_name:
         return None, None, None
-    
+
     # 1. Exact match on shortName
     if cve_name in short_name_map:
-        return short_name_map[cve_name], 'exact_short', 'high'
-    
+        return short_name_map[cve_name], "exact_short", "high"
+
     # 2. Case-insensitive match on shortName
     cve_lower = cve_name.lower()
     if cve_lower in short_name_map:
-        return short_name_map[cve_lower], 'case_short', 'high'
-    
+        return short_name_map[cve_lower], "case_short", "high"
+
     # 3. Exact match on organizationName
     if cve_name in org_name_map:
-        return org_name_map[cve_name], 'exact_org', 'high'
-    
+        return org_name_map[cve_name], "exact_org", "high"
+
     # 4. Case-insensitive match on organizationName
     if cve_lower in org_name_map:
-        return org_name_map[cve_lower], 'case_org', 'high'
-    
+        return org_name_map[cve_lower], "case_org", "high"
+
     # 5. Normalized match
     normalized_cve = normalize_name(cve_name)
     if normalized_cve and normalized_cve in normalized_map:
-        return normalized_map[normalized_cve], 'normalized', 'medium'
-    
+        return normalized_map[normalized_cve], "normalized", "medium"
+
     # 6. Partial matching (substring containment)
     # Only for names with reasonable length to avoid false positives
     if len(cve_name) > 3:
         for cna in cna_list:
-            short = cna.get('shortName', '').lower()
-            org = cna.get('organizationName', '').lower()
-            
+            short = cna.get("shortName", "").lower()
+            org = cna.get("organizationName", "").lower()
+
             # Check if CVE name contains official name or vice versa
             if short and len(short) > 3:
                 if cve_lower in short or short in cve_lower:
-                    return cna, 'partial', 'low'
-            
+                    return cna, "partial", "low"
+
             if org and len(org) > 5:
                 if cve_lower in org or org in cve_lower:
-                    return cna, 'partial', 'low'
-    
+                    return cna, "partial", "low"
+
     return None, None, None
 
 
 def analyze_cna_names(cna_analysis: dict[str, Any], official_cna_list: list[dict[str, Any]]) -> dict[str, Any]:
     """
     Analyze all CNA names from our analysis against the official registry.
-    
+
     Returns categorized results with match information.
     """
     # Build lookup structures
     short_name_map, org_name_map, all_official_names, normalized_map = build_official_cna_lookups(official_cna_list)
-    
+
     # Results
-    exact_matches = []      # Exact shortName match - official and correct
-    case_matches = []       # Case mismatch - should standardize
-    org_matches = []        # Matched via organizationName - should use shortName
-    normalized_matches = [] # Matched via normalization - naming inconsistency
-    partial_matches = []    # Partial match - likely the same but different naming
-    unmatched = []          # No match found - potentially not a registered CNA
-    
+    exact_matches = []  # Exact shortName match - official and correct
+    case_matches = []  # Case mismatch - should standardize
+    org_matches = []  # Matched via organizationName - should use shortName
+    normalized_matches = []  # Matched via normalization - naming inconsistency
+    partial_matches = []  # Partial match - likely the same but different naming
+    unmatched = []  # No match found - potentially not a registered CNA
+
     # Also track the match details
     match_details = {}
-    
+
     for cna_name, cna_data in cna_analysis.items():
         official, match_type, confidence = map_cve_name_to_official(
             cna_name, short_name_map, org_name_map, normalized_map, official_cna_list
         )
-        
+
         result = {
-            'cna_name': cna_name,
-            'cve_count': cna_data.get('count', 0),
-            'kev_count': cna_data.get('kev_count', 0),
-            'epss_high_count': cna_data.get('epss_high_count', 0),
+            "cna_name": cna_name,
+            "cve_count": cna_data.get("count", 0),
+            "kev_count": cna_data.get("kev_count", 0),
+            "epss_high_count": cna_data.get("epss_high_count", 0),
         }
-        
+
         if official:
-            result['official_short_name'] = official.get('shortName', '')
-            result['official_org_name'] = official.get('organizationName', '')
-            result['official_id'] = official.get('cnaID', '')
-            result['match_type'] = match_type
-            result['confidence'] = confidence
-            
+            result["official_short_name"] = official.get("shortName", "")
+            result["official_org_name"] = official.get("organizationName", "")
+            result["official_id"] = official.get("cnaID", "")
+            result["match_type"] = match_type
+            result["confidence"] = confidence
+
             match match_type:
-                case 'exact_short':
+                case "exact_short":
                     exact_matches.append(result)
-                case 'case_short':
+                case "case_short":
                     case_matches.append(result)
-                case 'exact_org' | 'case_org':
+                case "exact_org" | "case_org":
                     org_matches.append(result)
-                case 'normalized':
+                case "normalized":
                     normalized_matches.append(result)
-                case 'partial':
+                case "partial":
                     partial_matches.append(result)
         else:
-            result['match_type'] = None
-            result['confidence'] = None
+            result["match_type"] = None
+            result["confidence"] = None
             unmatched.append(result)
-        
+
         match_details[cna_name] = result
-    
+
     # Sort by CVE count descending
     for lst in [exact_matches, case_matches, org_matches, normalized_matches, partial_matches, unmatched]:
-        lst.sort(key=lambda x: x['cve_count'], reverse=True)
-    
+        lst.sort(key=lambda x: x["cve_count"], reverse=True)
+
     return {
-        'exact_matches': exact_matches,
-        'case_matches': case_matches,
-        'org_matches': org_matches,
-        'normalized_matches': normalized_matches,
-        'partial_matches': partial_matches,
-        'unmatched': unmatched,
-        'match_details': match_details
+        "exact_matches": exact_matches,
+        "case_matches": case_matches,
+        "org_matches": org_matches,
+        "normalized_matches": normalized_matches,
+        "partial_matches": partial_matches,
+        "unmatched": unmatched,
+        "match_details": match_details,
     }
 
 
 def main() -> None:
     """Main entry point."""
     logger.info("Rebuilding data quality analysis with CNAScorecard-style name matching...")
-    
+
     # Load official CNA list
     cna_list_path = CACHE_DIR / "cna_list.json"
     if not cna_list_path.exists():
         logger.error(f"Official CNA list not found at {cna_list_path}")
         sys.exit(1)
-    
+
     official_cna_list = load_json(cna_list_path)
     logger.info(f"Loaded {len(official_cna_list)} official CNAs from registry")
-    
+
     # Load our CNA analysis
     cna_analysis_path = WEB_DATA_DIR / "cna_analysis.json"
     if not cna_analysis_path.exists():
         logger.error(f"CNA analysis not found at {cna_analysis_path}")
         sys.exit(1)
-    
+
     cna_analysis = load_json(cna_analysis_path)
     # Convert cna_list array to dict keyed by name for analysis
-    cna_list_data = cna_analysis.get('cna_list', [])
-    cna_data = {item['name']: item for item in cna_list_data if 'name' in item}
+    cna_list_data = cna_analysis.get("cna_list", [])
+    cna_data = {item["name"]: item for item in cna_list_data if "name" in item}
     logger.info(f"Loaded {len(cna_data)} CNAs from analysis")
-    
+
     # Analyze names
     results = analyze_cna_names(cna_data, official_cna_list)
-    
+
     # Calculate statistics
     stats = {
-        'total_cnas_in_analysis': len(cna_data),
-        'official_cna_registry_count': len(official_cna_list),
-        'exact_matches': len(results['exact_matches']),
-        'case_mismatches': len(results['case_matches']),
-        'org_name_matches': len(results['org_matches']),
-        'normalized_matches': len(results['normalized_matches']),
-        'partial_matches': len(results['partial_matches']),
-        'unmatched': len(results['unmatched']),
+        "total_cnas_in_analysis": len(cna_data),
+        "official_cna_registry_count": len(official_cna_list),
+        "exact_matches": len(results["exact_matches"]),
+        "case_mismatches": len(results["case_matches"]),
+        "org_name_matches": len(results["org_matches"]),
+        "normalized_matches": len(results["normalized_matches"]),
+        "partial_matches": len(results["partial_matches"]),
+        "unmatched": len(results["unmatched"]),
     }
-    
+
     # Total CVEs in each category
-    stats['exact_match_cves'] = sum(x['cve_count'] for x in results['exact_matches'])
-    stats['case_mismatch_cves'] = sum(x['cve_count'] for x in results['case_matches'])
-    stats['org_name_match_cves'] = sum(x['cve_count'] for x in results['org_matches'])
-    stats['normalized_match_cves'] = sum(x['cve_count'] for x in results['normalized_matches'])
-    stats['partial_match_cves'] = sum(x['cve_count'] for x in results['partial_matches'])
-    stats['unmatched_cves'] = sum(x['cve_count'] for x in results['unmatched'])
-    
+    stats["exact_match_cves"] = sum(x["cve_count"] for x in results["exact_matches"])
+    stats["case_mismatch_cves"] = sum(x["cve_count"] for x in results["case_matches"])
+    stats["org_name_match_cves"] = sum(x["cve_count"] for x in results["org_matches"])
+    stats["normalized_match_cves"] = sum(x["cve_count"] for x in results["normalized_matches"])
+    stats["partial_match_cves"] = sum(x["cve_count"] for x in results["partial_matches"])
+    stats["unmatched_cves"] = sum(x["cve_count"] for x in results["unmatched"])
+
     # Calculate percentages
-    total_cves = sum([
-        stats['exact_match_cves'], stats['case_mismatch_cves'], 
-        stats['org_name_match_cves'], stats['normalized_match_cves'],
-        stats['partial_match_cves'], stats['unmatched_cves']
-    ])
-    
+    total_cves = sum(
+        [
+            stats["exact_match_cves"],
+            stats["case_mismatch_cves"],
+            stats["org_name_match_cves"],
+            stats["normalized_match_cves"],
+            stats["partial_match_cves"],
+            stats["unmatched_cves"],
+        ]
+    )
+
     if total_cves > 0:
-        stats['exact_match_pct'] = round(stats['exact_match_cves'] / total_cves * 100, 2)
-        stats['issues_pct'] = round((total_cves - stats['exact_match_cves']) / total_cves * 100, 2)
-    
+        stats["exact_match_pct"] = round(stats["exact_match_cves"] / total_cves * 100, 2)
+        stats["issues_pct"] = round((total_cves - stats["exact_match_cves"]) / total_cves * 100, 2)
+
     logger.info("=== Data Quality Summary ===")
     logger.info(f"Total CNAs analyzed: {stats['total_cnas_in_analysis']}")
     logger.info(f"Official registry size: {stats['official_cna_registry_count']}")
@@ -309,29 +318,29 @@ def main() -> None:
     logger.info(f"  Normalized matches: {stats['normalized_matches']} CNAs ({stats['normalized_match_cves']:,} CVEs)")
     logger.info(f"  Partial matches: {stats['partial_matches']} CNAs ({stats['partial_match_cves']:,} CVEs)")
     logger.info(f"  Unmatched: {stats['unmatched']} CNAs ({stats['unmatched_cves']:,} CVEs)")
-    
+
     # Build output
     output = {
-        'stats': stats,
-        'exact_matches': results['exact_matches'][:50],  # Top 50 only
-        'case_mismatches': results['case_matches'],
-        'org_name_matches': results['org_matches'],
-        'normalized_matches': results['normalized_matches'],
-        'partial_matches': results['partial_matches'],
-        'unmatched': results['unmatched'],
+        "stats": stats,
+        "exact_matches": results["exact_matches"][:50],  # Top 50 only
+        "case_mismatches": results["case_matches"],
+        "org_name_matches": results["org_matches"],
+        "normalized_matches": results["normalized_matches"],
+        "partial_matches": results["partial_matches"],
+        "unmatched": results["unmatched"],
     }
-    
+
     # Save to web data directory
     output_path = WEB_DATA_DIR / "data_quality.json"
     save_json(output_path, output)
     logger.info(f"Saved data quality analysis to {output_path}")
-    
+
     # Also print top unmatched for review
-    if results['unmatched']:
+    if results["unmatched"]:
         logger.info("=== Top 10 Unmatched CNAs ===")
-        for item in results['unmatched'][:10]:
+        for item in results["unmatched"][:10]:
             logger.info(f"  {item['cna_name']}: {item['cve_count']:,} CVEs")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/data/scripts/rebuild_growth.py
+++ b/data/scripts/rebuild_growth.py
@@ -3,17 +3,20 @@
 Growth Analysis Rebuild Script
 Standalone script to rebuild growth analysis data and regenerate the Growth Intelligence Dashboard
 """
+
 from __future__ import annotations
 
 import json
 import sys
 from pathlib import Path
 
+
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from scripts.utils import print_header, setup_paths
 from yearly_analysis import YearlyAnalyzer
-from scripts.utils import setup_paths, print_header
+
 
 # Logging setup
 try:
@@ -27,87 +30,87 @@ logger = get_logger(__name__)
 def main() -> bool:
     """Main function to rebuild growth analysis"""
     print_header("Growth Analysis Rebuild", "🚀")
-    
+
     try:
         # Initialize paths
         project_root, cache_dir, _ = setup_paths()
-        data_dir = project_root / 'data'  # Growth analysis uses data/ not web/data/
-        
+        data_dir = project_root / "data"  # Growth analysis uses data/ not web/data/
+
         logger.info(f"Base directory: {project_root}")
         logger.info(f"Cache directory: {cache_dir}")
         logger.info(f"Data directory: {data_dir}")
-        
+
         # Initialize analyzer
         logger.info("Initializing Growth Analyzer...")
         analyzer = YearlyAnalyzer(project_root, cache_dir, data_dir)
-        
+
         # Generate year data first (required for growth analysis)
         logger.info("Generating year data...")
         all_year_data = analyzer.generate_year_data_json()
-        
+
         if not all_year_data:
             logger.error("No year data available for growth analysis")
             return False
-        
+
         logger.info(f"Generated data for {len(all_year_data)} years")
-        
+
         # Generate comprehensive growth analysis
         logger.info("Generating comprehensive growth analysis...")
         growth_analysis = analyzer.generate_growth_analysis(all_year_data)
-        
+
         if growth_analysis:
             logger.info("Comprehensive growth analysis generated successfully")
-            
+
             # Display key statistics
-            growth_data = growth_analysis.get('growth_data', [])
+            growth_data = growth_analysis.get("growth_data", [])
             if growth_data:
                 latest_year = growth_data[-1]
                 logger.info(f"Latest year: {latest_year['year']} with {latest_year['cves']:,} CVEs")
                 logger.info(f"Average annual growth: {growth_analysis.get('avg_annual_growth', 0)}%")
-                
-                highest_growth = growth_analysis.get('highest_growth_year')
+
+                highest_growth = growth_analysis.get("highest_growth_year")
                 if highest_growth:
                     logger.info(f"Peak growth: {highest_growth['year']} ({highest_growth['growth_rate']}%)")
         else:
             logger.error("Failed to generate comprehensive growth analysis")
             return False
-        
+
         # Generate current year growth analysis
         logger.info("Generating current year growth analysis...")
         try:
             current_year = analyzer.current_year
-            current_year_data = next((d for d in all_year_data if d.get('year') == current_year), None)
-            
+            current_year_data = next((d for d in all_year_data if d.get("year") == current_year), None)
+
             if current_year_data:
                 # Create simplified current year growth analysis
                 current_year_growth = {
-                    'generated_at': growth_analysis['generated_at'],
-                    'year': current_year,
-                    'growth_data': [d for d in growth_data if d['year'] == current_year],
-                    'avg_annual_growth': 0,  # Not applicable for single year
-                    'highest_growth_year': None,  # Not applicable for single year
-                    'lowest_growth_year': None   # Not applicable for single year
+                    "generated_at": growth_analysis["generated_at"],
+                    "year": current_year,
+                    "growth_data": [d for d in growth_data if d["year"] == current_year],
+                    "avg_annual_growth": 0,  # Not applicable for single year
+                    "highest_growth_year": None,  # Not applicable for single year
+                    "lowest_growth_year": None,  # Not applicable for single year
                 }
-                
+
                 # Save current year analysis
-                current_year_file = data_dir / 'growth_analysis_current_year.json'
-                with open(current_year_file, 'w') as f:
+                current_year_file = data_dir / "growth_analysis_current_year.json"
+                with open(current_year_file, "w") as f:
                     json.dump(current_year_growth, f, indent=2)
-                
+
                 logger.info(f"Current year ({current_year}) growth analysis generated")
             else:
                 logger.warning(f"No data found for current year {current_year}")
-        
+
         except (KeyError, json.JSONDecodeError, OSError) as e:
             logger.error(f"Error generating current year growth analysis: {e}")
-        
+
         logger.info("Growth analysis rebuild completed successfully!")
         logger.info("Files generated:")
         logger.info("  • growth_analysis.json (comprehensive)")
         logger.info("  • growth_analysis_current_year.json (current year)")
-        
+
         return True
-        
+
     except ImportError as e:
         logger.error(f"Import error: {e}")
         logger.info("Make sure all required modules are available")
@@ -115,9 +118,11 @@ def main() -> bool:
     except (OSError, json.JSONDecodeError, KeyError) as e:
         logger.error(f"File or data error: {e}")
         import traceback
+
         traceback.print_exc()
         return False
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     success = main()
     sys.exit(0 if success else 1)

--- a/data/scripts/rebuild_growth.py
+++ b/data/scripts/rebuild_growth.py
@@ -21,8 +21,8 @@ from yearly_analysis import YearlyAnalyzer
 # Logging setup
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/rebuild_templates.py
+++ b/data/scripts/rebuild_templates.py
@@ -21,8 +21,8 @@ web_dir = project_root / "web"
 sys.path.insert(0, str(project_root / "data"))
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/scripts/rebuild_templates.py
+++ b/data/scripts/rebuild_templates.py
@@ -2,6 +2,7 @@
 """
 Quick template rebuild script - regenerates HTML pages without reprocessing data
 """
+
 from __future__ import annotations
 
 import sys
@@ -10,13 +11,14 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
+
 # Get project root (scripts -> data -> project root)
 project_root = Path(__file__).parent.parent.parent
-template_dir = project_root / 'templates'
-web_dir = project_root / 'web'
+template_dir = project_root / "templates"
+web_dir = project_root / "web"
 
 # Logging setup
-sys.path.insert(0, str(project_root / 'data'))
+sys.path.insert(0, str(project_root / "data"))
 try:
     from data.logging_config import get_logger
 except ImportError:
@@ -34,22 +36,16 @@ logger.info("Rebuilding HTML templates...")
 
 # Rebuild index.html
 logger.info("Rebuilding index.html...")
-template = env.get_template('index.html')
-output = template.render(
-    current_year=current_year,
-    available_years=list(range(1999, current_year + 1))
-)
-with open(web_dir / 'index.html', 'w') as f:
+template = env.get_template("index.html")
+output = template.render(current_year=current_year, available_years=list(range(1999, current_year + 1)))
+with open(web_dir / "index.html", "w") as f:
     f.write(output)
 
 # Rebuild growth.html
 logger.info("Rebuilding growth.html...")
-template = env.get_template('growth.html')
-output = template.render(
-    title='Growth Intelligence Dashboard',
-    current_year=current_year
-)
-with open(web_dir / 'growth.html', 'w') as f:
+template = env.get_template("growth.html")
+output = template.render(title="Growth Intelligence Dashboard", current_year=current_year)
+with open(web_dir / "growth.html", "w") as f:
     f.write(output)
 
 logger.info("Templates rebuilt successfully!")

--- a/data/scripts/utils.py
+++ b/data/scripts/utils.py
@@ -2,12 +2,14 @@
 """
 Shared utilities for rebuild scripts
 """
+
 from __future__ import annotations
 
 import json
 import sys
 from datetime import datetime
 from pathlib import Path
+
 
 # Logging setup
 try:
@@ -29,7 +31,7 @@ logger = get_logger(__name__)
 def setup_paths() -> tuple[Path, Path, Path]:
     """
     Set up paths and ensure parent modules are importable.
-    
+
     Returns:
         tuple: (project_root, cache_dir, data_dir)
     """
@@ -37,43 +39,43 @@ def setup_paths() -> tuple[Path, Path, Path]:
     scripts_dir = Path(__file__).parent
     data_module_dir = scripts_dir.parent
     project_root = data_module_dir.parent
-    
+
     # Add data/ to path for importing analysis modules
     if str(data_module_dir) not in sys.path:
         sys.path.insert(0, str(data_module_dir))
-    
-    cache_dir = data_module_dir / 'cache'
-    web_data_dir = project_root / 'web' / 'data'
-    
+
+    cache_dir = data_module_dir / "cache"
+    web_data_dir = project_root / "web" / "data"
+
     # Ensure directories exist
     web_data_dir.mkdir(parents=True, exist_ok=True)
-    
+
     return project_root, cache_dir, web_data_dir
 
 
 def load_all_year_data(data_dir: Path) -> list[dict]:
     """
     Load all existing year data files.
-    
+
     Args:
         data_dir: Path to web/data directory containing cve_YYYY.json files
-        
+
     Returns:
         List of year data dictionaries
     """
     all_year_data: list[dict] = []
     current_year = datetime.now().year
-    
+
     for year in range(1999, current_year + 1):
-        year_file = data_dir / f'cve_{year}.json'
+        year_file = data_dir / f"cve_{year}.json"
         if year_file.exists():
             try:
-                with open(year_file, 'r') as f:
+                with open(year_file) as f:
                     year_data = json.load(f)
                 all_year_data.append(year_data)
             except (FileNotFoundError, json.JSONDecodeError, OSError) as e:
                 logger.warning(f"Error loading {year_file}: {e}")
-    
+
     return all_year_data
 
 

--- a/data/vendor_analysis.py
+++ b/data/vendor_analysis.py
@@ -15,8 +15,8 @@ from typing import Any
 
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 

--- a/data/vendor_analysis.py
+++ b/data/vendor_analysis.py
@@ -3,13 +3,15 @@
 Vendor Analysis Module
 Handles all vendor/CPE (Common Platform Enumeration) related data processing and analysis
 """
+
 from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 from typing import Any
+
 
 try:
     from data.logging_config import get_logger
@@ -22,88 +24,86 @@ logger = get_logger(__name__)
 @dataclass
 class VendorAnalyzer:
     """Handles vendor/CPE-specific analysis and data processing"""
+
     base_dir: Path
     cache_dir: Path
     data_dir: Path
     current_year: int = field(default_factory=lambda: datetime.now().year)
-    
+
     def __post_init__(self) -> None:
         """Convert path arguments to Path objects if needed."""
         self.base_dir = Path(self.base_dir)
         self.cache_dir = Path(self.cache_dir)
         self.data_dir = Path(self.data_dir)
-    
+
     def generate_vendor_analysis(self, all_year_data: list[dict[str, Any]]) -> dict[str, Any]:
         """Generate CPE vendor analysis across all years"""
-        logger.info(f"  🏢 Generating vendor/CPE analysis...")
-        
+        logger.info("  🏢 Generating vendor/CPE analysis...")
+
         # Aggregate vendor data from all years
         combined_vendors = {}
         total_cves_with_vendors = 0
-        
+
         for year_data in all_year_data:
-            if 'vendors' in year_data and 'cpe_vendors' in year_data['vendors']:
-                total_cves_with_vendors += year_data['vendors'].get('total_cves_with_vendors', 0)
-                
+            if "vendors" in year_data and "cpe_vendors" in year_data["vendors"]:
+                total_cves_with_vendors += year_data["vendors"].get("total_cves_with_vendors", 0)
+
                 # Aggregate vendor counts
-                for vendor_entry in year_data['vendors']['cpe_vendors']:
-                    vendor_name = vendor_entry['name']
-                    count = vendor_entry['count']
-                    
+                for vendor_entry in year_data["vendors"]["cpe_vendors"]:
+                    vendor_name = vendor_entry["name"]
+                    count = vendor_entry["count"]
+
                     if vendor_name not in combined_vendors:
-                        combined_vendors[vendor_name] = {
-                            'name': vendor_name,
-                            'count': 0
-                        }
-                    
-                    combined_vendors[vendor_name]['count'] += count
-        
+                        combined_vendors[vendor_name] = {"name": vendor_name, "count": 0}
+
+                    combined_vendors[vendor_name]["count"] += count
+
         # Sort by count and get top vendors
-        top_vendors = sorted(combined_vendors.values(), key=lambda x: x['count'], reverse=True)
-        
+        top_vendors = sorted(combined_vendors.values(), key=lambda x: x["count"], reverse=True)
+
         vendor_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'total_cves_with_vendors': total_cves_with_vendors,
-            'total_unique_vendors': len(combined_vendors),
-            'top_vendors': top_vendors[:100],  # Top 100 vendors
-            'top_vendors_limited': top_vendors[:20]  # Top 20 for charts
+            "generated_at": datetime.now().isoformat(),
+            "total_cves_with_vendors": total_cves_with_vendors,
+            "total_unique_vendors": len(combined_vendors),
+            "top_vendors": top_vendors[:100],  # Top 100 vendors
+            "top_vendors_limited": top_vendors[:20],  # Top 20 for charts
         }
-        
+
         # Save to file
-        output_file = self.data_dir / 'vendor_analysis.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "vendor_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(vendor_analysis, f, indent=2)
-        
+
         logger.info(f"  ✅ Generated vendor analysis with {len(combined_vendors):,} unique vendors")
         return vendor_analysis
-    
+
     def generate_current_year_vendor_analysis(self, current_year_data: dict[str, Any]) -> dict[str, Any]:
         """Generate current year vendor analysis"""
-        logger.info(f"    🏢 Generating current year vendor analysis...")
-        
+        logger.info("    🏢 Generating current year vendor analysis...")
+
         # Extract vendor data from current year
-        vendor_data = current_year_data.get('vendors', {})
-        
-        if not vendor_data or 'cpe_vendors' not in vendor_data:
+        vendor_data = current_year_data.get("vendors", {})
+
+        if not vendor_data or "cpe_vendors" not in vendor_data:
             logger.warning(f"    ⚠️  No vendor data found for {self.current_year}")
             return {}
-        
+
         # Get current year vendors
-        current_year_vendors = vendor_data['cpe_vendors']
-        
+        current_year_vendors = vendor_data["cpe_vendors"]
+
         current_year_vendor_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'year': self.current_year,
-            'total_cves_with_vendors': vendor_data.get('total_cves_with_vendors', 0),
-            'total_unique_vendors': len(current_year_vendors),
-            'top_vendors': current_year_vendors[:100],  # Top 100 vendors
-            'top_vendors_limited': current_year_vendors[:20]  # Top 20 for charts
+            "generated_at": datetime.now().isoformat(),
+            "year": self.current_year,
+            "total_cves_with_vendors": vendor_data.get("total_cves_with_vendors", 0),
+            "total_unique_vendors": len(current_year_vendors),
+            "top_vendors": current_year_vendors[:100],  # Top 100 vendors
+            "top_vendors_limited": current_year_vendors[:20],  # Top 20 for charts
         }
-        
+
         # Save current year analysis
-        current_year_file = self.data_dir / 'vendor_analysis_current_year.json'
-        with open(current_year_file, 'w') as f:
+        current_year_file = self.data_dir / "vendor_analysis_current_year.json"
+        with open(current_year_file, "w") as f:
             json.dump(current_year_vendor_analysis, f, indent=2)
-        
+
         logger.info(f"    ✅ Generated current year vendor analysis with {len(current_year_vendors)} vendors")
         return current_year_vendor_analysis

--- a/data/yearly_analysis.py
+++ b/data/yearly_analysis.py
@@ -3,13 +3,15 @@
 Yearly Analysis Module
 Handles year-by-year data processing and aggregation
 """
+
 from __future__ import annotations
 
 import json
 from dataclasses import dataclass, field
-from pathlib import Path
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any
+
 
 # Logging setup
 try:
@@ -23,103 +25,106 @@ logger = get_logger(__name__)
 @dataclass
 class YearlyAnalyzer:
     """Handles yearly data processing and aggregation"""
+
     base_dir: Path
     cache_dir: Path
     data_dir: Path
     quiet: bool = False
     current_year: int = field(default_factory=lambda: datetime.now().year)
     available_years: list[int] = field(init=False)
-    
+
     def __post_init__(self) -> None:
         """Convert path arguments and set up derived attributes."""
         self.base_dir = Path(self.base_dir)
         self.cache_dir = Path(self.cache_dir)
         self.data_dir = Path(self.data_dir)
         self.available_years = list(range(1999, self.current_year + 1))
-    
+
     def calculate_actual_ytd_count(self, year: int, day_of_year: int) -> int:
         """Calculate actual YTD CVE count for a given year up to specific day of year"""
         try:
             # Use the already-generated year data file which contains daily counts
-            year_file = self.data_dir / f'cve_{year}.json'
-            
+            year_file = self.data_dir / f"cve_{year}.json"
+
             if not year_file.exists():
                 if not self.quiet:
                     print(f"⚠️  Warning: Year file for {year} not found")
                 return 0
-            
+
             import json
-            with open(year_file, 'r') as f:
+
+            with open(year_file) as f:
                 year_data = json.load(f)
-            
+
             # Get daily counts from the pre-processed data
-            daily_counts = year_data.get('date_data', {}).get('daily_analysis', {}).get('daily_counts', {})
-            
+            daily_counts = year_data.get("date_data", {}).get("daily_analysis", {}).get("daily_counts", {})
+
             # Sum up CVEs from Jan 1 to the target day of year
             ytd_count = 0
             for day_num in range(1, day_of_year + 1):
-                date_key = (datetime(year, 1, 1) + timedelta(days=day_num - 1)).strftime('%Y-%m-%d')
+                date_key = (datetime(year, 1, 1) + timedelta(days=day_num - 1)).strftime("%Y-%m-%d")
                 ytd_count += daily_counts.get(date_key, 0)
-            
+
             return ytd_count
-            
+
         except (FileNotFoundError, json.JSONDecodeError, OSError, ImportError) as e:
             if not self.quiet:
                 print(f"⚠️  Warning: Could not calculate actual YTD for {year}: {e}")
             # Fallback: try to use uniform distribution if we have the year data file
             try:
-                year_file = self.data_dir / f'cve_{year}.json'
+                year_file = self.data_dir / f"cve_{year}.json"
                 if year_file.exists():
                     import json
-                    with open(year_file, 'r') as f:
+
+                    with open(year_file) as f:
                         year_data = json.load(f)
-                    total_cves = year_data.get('total_cves', 0)
+                    total_cves = year_data.get("total_cves", 0)
                     days_in_year = 366 if year % 4 == 0 else 365
                     return int((total_cves / days_in_year) * day_of_year)
             except (OSError, json.JSONDecodeError, TypeError, ValueError):
                 pass
             return 0
-    
+
     def generate_year_data_json(self) -> list[dict[str, Any]]:
         """Generate JSON data files for all available years"""
         if not self.quiet:
             logger.info("Generating year data JSON files...")
-        
+
         try:
             # Import the years analyzer
             from cve_years import CVEYearsAnalyzer
-            
+
             if not self.quiet:
                 logger.info("Initializing CVE data processing...")
             analyzer = CVEYearsAnalyzer(quiet=self.quiet)
-            
+
             # Generate data for all years
             all_year_data = []
-            
+
             for year in self.available_years:
                 logger.debug(f"Processing {year}...")
-                
+
                 try:
                     year_data = analyzer.get_year_data(year)
-                    
+
                     if year_data:
                         # Save individual year file
-                        year_file = self.data_dir / f'cve_{year}.json'
-                        with open(year_file, 'w') as f:
+                        year_file = self.data_dir / f"cve_{year}.json"
+                        with open(year_file, "w") as f:
                             json.dump(year_data, f, indent=2)
-                        
+
                         all_year_data.append(year_data)
                         logger.info(f"Generated cve_{year}.json ({year_data.get('total_cves', 0):,} CVEs)")
                     else:
                         logger.warning(f"No data available for {year}")
-                        
+
                 except (KeyError, json.JSONDecodeError, OSError) as e:
                     logger.error(f"Failed to process {year}: {e}")
                     continue
-            
+
             logger.info(f"Generated {len(all_year_data)} year data files")
             return all_year_data
-            
+
         except ImportError as e:
             logger.error(f"Failed to import CVE years analyzer: {e}")
             logger.info("Creating placeholder data for development...")
@@ -127,254 +132,264 @@ class YearlyAnalyzer:
         except (json.JSONDecodeError, OSError, KeyError) as e:
             logger.error(f"Error generating year data: {e}")
             return []
-    
+
     def create_placeholder_year_data(self) -> list[dict[str, Any]]:
         """Create placeholder year data for development/testing"""
         logger.info("Creating placeholder year data...")
-        
+
         all_year_data = []
-        
+
         for year in self.available_years:
             # Create basic placeholder data structure
             year_data = {
-                'year': year,
-                'total_cves': max(100, (year - 1999) * 500),  # Increasing trend
-                'date_data': {
-                    'monthly_distribution': {str(i): max(10, (year - 1999) * 5) for i in range(1, 13)},
-                    'daily_analysis': {
-                        'total_days': 365,
-                        'days_with_cves': min(365, max(50, (year - 1999) * 10)),
-                        'avg_cves_per_day': max(1, (year - 1999) * 1.5),
-                        'max_cves_in_day': max(5, (year - 1999) * 3),
-                        'daily_counts': {}
-                    }
+                "year": year,
+                "total_cves": max(100, (year - 1999) * 500),  # Increasing trend
+                "date_data": {
+                    "monthly_distribution": {str(i): max(10, (year - 1999) * 5) for i in range(1, 13)},
+                    "daily_analysis": {
+                        "total_days": 365,
+                        "days_with_cves": min(365, max(50, (year - 1999) * 10)),
+                        "avg_cves_per_day": max(1, (year - 1999) * 1.5),
+                        "max_cves_in_day": max(5, (year - 1999) * 3),
+                        "daily_counts": {},
+                    },
                 },
-                'vendors': {
-                    'total_cves_with_vendors': max(80, (year - 1999) * 400),
-                    'cpe_vendors': [
-                        {'name': 'Microsoft Corporation', 'count': max(20, (year - 1999) * 50)},
-                        {'name': 'Adobe Inc.', 'count': max(15, (year - 1999) * 30)},
-                        {'name': 'Oracle Corporation', 'count': max(10, (year - 1999) * 25)},
-                        {'name': 'Google LLC', 'count': max(8, (year - 1999) * 20)},
-                        {'name': 'Apple Inc.', 'count': max(5, (year - 1999) * 15)}
+                "vendors": {
+                    "total_cves_with_vendors": max(80, (year - 1999) * 400),
+                    "cpe_vendors": [
+                        {"name": "Microsoft Corporation", "count": max(20, (year - 1999) * 50)},
+                        {"name": "Adobe Inc.", "count": max(15, (year - 1999) * 30)},
+                        {"name": "Oracle Corporation", "count": max(10, (year - 1999) * 25)},
+                        {"name": "Google LLC", "count": max(8, (year - 1999) * 20)},
+                        {"name": "Apple Inc.", "count": max(5, (year - 1999) * 15)},
                     ],
-                    'cna_assigners': [
-                        {'name': 'MITRE Corporation', 'count': max(50, (year - 1999) * 100)},
-                        {'name': 'Patchstack', 'count': max(20, (year - 1999) * 40)},
-                        {'name': 'Microsoft Corporation', 'count': max(15, (year - 1999) * 30)},
-                        {'name': 'Adobe Inc.', 'count': max(10, (year - 1999) * 25)},
-                        {'name': 'Wordfence', 'count': max(8, (year - 1999) * 20)}
-                    ]
+                    "cna_assigners": [
+                        {"name": "MITRE Corporation", "count": max(50, (year - 1999) * 100)},
+                        {"name": "Patchstack", "count": max(20, (year - 1999) * 40)},
+                        {"name": "Microsoft Corporation", "count": max(15, (year - 1999) * 30)},
+                        {"name": "Adobe Inc.", "count": max(10, (year - 1999) * 25)},
+                        {"name": "Wordfence", "count": max(8, (year - 1999) * 20)},
+                    ],
                 },
-                'cvss': {
-                    'total_cves_with_cvss': max(70, (year - 1999) * 350),
-                    'v2.0': {
-                        'severity': {'LOW': 10, 'MEDIUM': 30, 'HIGH': 20},
-                        'scores': {'2.1': 5, '5.0': 15, '7.5': 10, '9.3': 8}
+                "cvss": {
+                    "total_cves_with_cvss": max(70, (year - 1999) * 350),
+                    "v2.0": {
+                        "severity": {"LOW": 10, "MEDIUM": 30, "HIGH": 20},
+                        "scores": {"2.1": 5, "5.0": 15, "7.5": 10, "9.3": 8},
                     },
-                    'v3.0': {
-                        'severity': {'LOW': 15, 'MEDIUM': 40, 'HIGH': 25, 'CRITICAL': 10},
-                        'scores': {'3.1': 8, '5.4': 20, '7.8': 15, '9.8': 12}
+                    "v3.0": {
+                        "severity": {"LOW": 15, "MEDIUM": 40, "HIGH": 25, "CRITICAL": 10},
+                        "scores": {"3.1": 8, "5.4": 20, "7.8": 15, "9.8": 12},
                     },
-                    'v3.1': {
-                        'severity': {'LOW': 20, 'MEDIUM': 50, 'HIGH': 30, 'CRITICAL': 15},
-                        'scores': {'2.7': 10, '5.9': 25, '8.1': 18, '9.9': 15}
-                    }
+                    "v3.1": {
+                        "severity": {"LOW": 20, "MEDIUM": 50, "HIGH": 30, "CRITICAL": 15},
+                        "scores": {"2.7": 10, "5.9": 25, "8.1": 18, "9.9": 15},
+                    },
                 },
-                'cwe': {
-                    'total_cves_with_cwe': max(60, (year - 1999) * 300),
-                    'top_cwes': [
-                        {'id': '79', 'name': 'Cross-site Scripting (XSS)', 'count': max(10, (year - 1999) * 20)},
-                        {'id': '89', 'name': 'SQL Injection', 'count': max(8, (year - 1999) * 15)},
-                        {'id': '20', 'name': 'Improper Input Validation', 'count': max(6, (year - 1999) * 12)},
-                        {'id': '22', 'name': 'Path Traversal', 'count': max(5, (year - 1999) * 10)},
-                        {'id': '352', 'name': 'Cross-Site Request Forgery (CSRF)', 'count': max(4, (year - 1999) * 8)}
-                    ]
-                }
+                "cwe": {
+                    "total_cves_with_cwe": max(60, (year - 1999) * 300),
+                    "top_cwes": [
+                        {"id": "79", "name": "Cross-site Scripting (XSS)", "count": max(10, (year - 1999) * 20)},
+                        {"id": "89", "name": "SQL Injection", "count": max(8, (year - 1999) * 15)},
+                        {"id": "20", "name": "Improper Input Validation", "count": max(6, (year - 1999) * 12)},
+                        {"id": "22", "name": "Path Traversal", "count": max(5, (year - 1999) * 10)},
+                        {"id": "352", "name": "Cross-Site Request Forgery (CSRF)", "count": max(4, (year - 1999) * 8)},
+                    ],
+                },
             }
-            
+
             # Save individual year file
-            year_file = self.data_dir / f'cve_{year}.json'
-            with open(year_file, 'w') as f:
+            year_file = self.data_dir / f"cve_{year}.json"
+            with open(year_file, "w") as f:
                 json.dump(year_data, f, indent=2)
-            
+
             all_year_data.append(year_data)
             logger.debug(f"Created placeholder cve_{year}.json")
-        
+
         logger.info(f"Created {len(all_year_data)} placeholder year files")
         return all_year_data
-    
+
     def generate_cve_all_json(self, all_year_data: list[dict[str, Any]]) -> dict[str, Any]:
         """Generate overall CVE statistics across all years"""
         logger.info("Generating overall CVE statistics...")
-        
+
         # Calculate totals and trends
-        total_cves = sum(year['total_cves'] for year in all_year_data)
+        total_cves = sum(year["total_cves"] for year in all_year_data)
         years_with_data = len(all_year_data)
-        
+
         # Find peak year
-        peak_year_data = max(all_year_data, key=lambda x: x['total_cves'])
-        peak_year = peak_year_data['year']
-        peak_count = peak_year_data['total_cves']
-        
+        peak_year_data = max(all_year_data, key=lambda x: x["total_cves"])
+        peak_year = peak_year_data["year"]
+        peak_count = peak_year_data["total_cves"]
+
         # Calculate current year stats
-        current_year_data = next((year for year in all_year_data if year['year'] == self.current_year), None)
-        current_year_count = current_year_data['total_cves'] if current_year_data else 0
-        
+        current_year_data = next((year for year in all_year_data if year["year"] == self.current_year), None)
+        current_year_count = current_year_data["total_cves"] if current_year_data else 0
+
         # Calculate YoY growth (current vs previous year)
-        previous_year_data = next((year for year in all_year_data if year['year'] == self.current_year - 1), None)
-        previous_year_count = previous_year_data['total_cves'] if previous_year_data else 0
-        
+        previous_year_data = next((year for year in all_year_data if year["year"] == self.current_year - 1), None)
+        previous_year_count = previous_year_data["total_cves"] if previous_year_data else 0
+
         yoy_growth = 0
         if previous_year_count > 0:
             yoy_growth = ((current_year_count - previous_year_count) / previous_year_count) * 100
-        
+
         # Calculate average CVEs per day for current year
         avg_cves_per_day = 0
         if current_year_data:
             days_elapsed = datetime.now().timetuple().tm_yday
             avg_cves_per_day = current_year_count / days_elapsed if days_elapsed > 0 else 0
-        
+
         # Create yearly trend data for charts
         yearly_data = []
-        for year_data in sorted(all_year_data, key=lambda x: x['year']):
-            yearly_data.append({
-                'year': year_data['year'],
-                'count': year_data['total_cves']
-            })
-        
+        for year_data in sorted(all_year_data, key=lambda x: x["year"]):
+            yearly_data.append({"year": year_data["year"], "count": year_data["total_cves"]})
+
         cve_all_data = {
-            'generated_at': datetime.now().isoformat(),
-            'total_cves': total_cves,
-            'years_covered': years_with_data,
-            'current_year': self.current_year,
-            'current_year_cves': current_year_count,
-            'peak_year': peak_year,
-            'peak_count': peak_count,
-            'yoy_growth_rate': round(yoy_growth, 1),
-            'avg_cves_per_day': round(avg_cves_per_day, 1),
-            'yearly_trend': yearly_data
+            "generated_at": datetime.now().isoformat(),
+            "total_cves": total_cves,
+            "years_covered": years_with_data,
+            "current_year": self.current_year,
+            "current_year_cves": current_year_count,
+            "peak_year": peak_year,
+            "peak_count": peak_count,
+            "yoy_growth_rate": round(yoy_growth, 1),
+            "avg_cves_per_day": round(avg_cves_per_day, 1),
+            "yearly_trend": yearly_data,
         }
-        
+
         # Save to file
-        output_file = self.data_dir / 'cve_all.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "cve_all.json"
+        with open(output_file, "w") as f:
             json.dump(cve_all_data, f, indent=2)
-        
+
         logger.info(f"Generated cve_all.json with {total_cves:,} total CVEs")
         return cve_all_data
-    
+
     def generate_growth_analysis(self, all_year_data: list[dict[str, Any]]) -> dict[str, Any]:
         """Generate growth trend analysis across all years"""
         logger.info("Generating growth trend analysis...")
-        
+
         # Get current date for year-to-date calculations
         current_date = datetime.now()
         current_year = current_date.year
         day_of_year = current_date.timetuple().tm_yday
-        
+
         # Calculate year-over-year growth rates
         growth_data = []
-        
-        for i, year_data in enumerate(sorted(all_year_data, key=lambda x: x['year'])):
+
+        for i, year_data in enumerate(sorted(all_year_data, key=lambda x: x["year"])):
             if i == 0:
                 # First year, no previous data for comparison
-                growth_data.append({
-                    'year': year_data['year'],
-                    'cves': year_data['total_cves'],
-                    'growth_rate': 0,
-                    'growth_absolute': 0,
-                    'is_ytd': year_data['year'] == current_year
-                })
+                growth_data.append(
+                    {
+                        "year": year_data["year"],
+                        "cves": year_data["total_cves"],
+                        "growth_rate": 0,
+                        "growth_absolute": 0,
+                        "is_ytd": year_data["year"] == current_year,
+                    }
+                )
             else:
-                prev_year_data = sorted(all_year_data, key=lambda x: x['year'])[i-1]
-                prev_count = prev_year_data['total_cves']
-                current_count = year_data['total_cves']
-                
+                prev_year_data = sorted(all_year_data, key=lambda x: x["year"])[i - 1]
+                prev_count = prev_year_data["total_cves"]
+                current_count = year_data["total_cves"]
+
                 # For current year, we need to calculate YTD comparison
-                if year_data['year'] == current_year:
+                if year_data["year"] == current_year:
                     # Calculate proper YTD comparison: current YTD vs same period last year
                     # We need to get CVEs from previous year up to the same day of year
-                    
+
                     # First, calculate projected full year for growth rate
                     days_in_year = 366 if current_year % 4 == 0 else 365
                     projected_full_year = (current_count / day_of_year) * days_in_year
-                    
+
                     # Calculate ACTUAL YTD count for previous year using same date filtering
                     # This fixes the major bug of using uniform distribution assumption
                     prev_year_ytd_actual = self.calculate_actual_ytd_count(current_year - 1, day_of_year)
-                    
+
                     # Calculate true YTD comparison (current YTD vs previous year actual same period)
                     # This should be the PRIMARY growth rate for YTD data
                     ytd_comparison = 0
                     if prev_year_ytd_actual > 0:
                         ytd_comparison = ((current_count - prev_year_ytd_actual) / prev_year_ytd_actual) * 100
-                    
+
                     # Calculate projected full year for reference but don't use as main growth rate
                     projected_full_year = (current_count / day_of_year) * days_in_year
-                    
-                    growth_data.append({
-                        'year': year_data['year'],
-                        'cves': current_count,
-                        'growth_rate': round(ytd_comparison, 1),  # Use YTD comparison as main growth rate!
-                        'growth_absolute': int(current_count - prev_year_ytd_actual),  # YTD absolute change
-                        'is_ytd': True,
-                        'projected_full_year': int(projected_full_year),
-                        'ytd_vs_prev_full': round(((current_count - prev_count) / prev_count) * 100, 1) if prev_count > 0 else 0,
-                        'ytd_vs_prev_ytd': round(ytd_comparison, 1),
-                        'prev_year_ytd_actual': int(prev_year_ytd_actual)
-                    })
+
+                    growth_data.append(
+                        {
+                            "year": year_data["year"],
+                            "cves": current_count,
+                            "growth_rate": round(ytd_comparison, 1),  # Use YTD comparison as main growth rate!
+                            "growth_absolute": int(current_count - prev_year_ytd_actual),  # YTD absolute change
+                            "is_ytd": True,
+                            "projected_full_year": int(projected_full_year),
+                            "ytd_vs_prev_full": round(((current_count - prev_count) / prev_count) * 100, 1)
+                            if prev_count > 0
+                            else 0,
+                            "ytd_vs_prev_ytd": round(ytd_comparison, 1),
+                            "prev_year_ytd_actual": int(prev_year_ytd_actual),
+                        }
+                    )
                 else:
                     # Normal year-over-year calculation for completed years
                     growth_rate = 0
                     if prev_count > 0:
                         growth_rate = ((current_count - prev_count) / prev_count) * 100
-                    
-                    growth_data.append({
-                        'year': year_data['year'],
-                        'cves': current_count,
-                        'growth_rate': round(growth_rate, 1),
-                        'growth_absolute': current_count - prev_count,
-                        'is_ytd': False
-                    })
-        
+
+                    growth_data.append(
+                        {
+                            "year": year_data["year"],
+                            "cves": current_count,
+                            "growth_rate": round(growth_rate, 1),
+                            "growth_absolute": current_count - prev_count,
+                            "is_ytd": False,
+                        }
+                    )
+
         # Calculate moving averages (exclude current year from averages since it's YTD)
         window_size = 3
         for i, entry in enumerate(growth_data):
-            if entry.get('is_ytd', False):
+            if entry.get("is_ytd", False):
                 # For YTD data, don't calculate moving average
-                entry['growth_rate_3yr_avg'] = entry['growth_rate']
+                entry["growth_rate_3yr_avg"] = entry["growth_rate"]
             elif i >= window_size - 1:
                 # Only include completed years in moving average
-                window_rates = [growth_data[j]['growth_rate'] for j in range(i - window_size + 1, i + 1) 
-                               if not growth_data[j].get('is_ytd', False)]
+                window_rates = [
+                    growth_data[j]["growth_rate"]
+                    for j in range(i - window_size + 1, i + 1)
+                    if not growth_data[j].get("is_ytd", False)
+                ]
                 if window_rates:
-                    entry['growth_rate_3yr_avg'] = round(sum(window_rates) / len(window_rates), 1)
+                    entry["growth_rate_3yr_avg"] = round(sum(window_rates) / len(window_rates), 1)
                 else:
-                    entry['growth_rate_3yr_avg'] = entry['growth_rate']
+                    entry["growth_rate_3yr_avg"] = entry["growth_rate"]
             else:
-                entry['growth_rate_3yr_avg'] = entry['growth_rate']
-        
+                entry["growth_rate_3yr_avg"] = entry["growth_rate"]
+
         # Filter out YTD data for aggregate statistics since it's not comparable
-        completed_years = [entry for entry in growth_data[1:] if not entry.get('is_ytd', False)]
-        
+        completed_years = [entry for entry in growth_data[1:] if not entry.get("is_ytd", False)]
+
         # Get current year data for YTD comparison
-        current_year_data = next((entry for entry in growth_data if entry.get('is_ytd', False)), None)
-        
+        current_year_data = next((entry for entry in growth_data if entry.get("is_ytd", False)), None)
+
         growth_analysis = {
-            'generated_at': datetime.now().isoformat(),
-            'growth_data': growth_data,
-            'avg_annual_growth': round(sum(entry['growth_rate'] for entry in completed_years) / len(completed_years), 1) if completed_years else 0,
-            'highest_growth_year': max(completed_years, key=lambda x: x['growth_rate']) if completed_years else None,
-            'lowest_growth_year': min(completed_years, key=lambda x: x['growth_rate']) if completed_years else None,
-            'current_year_ytd': current_year_data
+            "generated_at": datetime.now().isoformat(),
+            "growth_data": growth_data,
+            "avg_annual_growth": round(sum(entry["growth_rate"] for entry in completed_years) / len(completed_years), 1)
+            if completed_years
+            else 0,
+            "highest_growth_year": max(completed_years, key=lambda x: x["growth_rate"]) if completed_years else None,
+            "lowest_growth_year": min(completed_years, key=lambda x: x["growth_rate"]) if completed_years else None,
+            "current_year_ytd": current_year_data,
         }
-        
+
         # Save to file
-        output_file = self.data_dir / 'growth_analysis.json'
-        with open(output_file, 'w') as f:
+        output_file = self.data_dir / "growth_analysis.json"
+        with open(output_file, "w") as f:
             json.dump(growth_analysis, f, indent=2)
-        
+
         if not self.quiet:
             logger.info(f"Generated growth analysis with {len(growth_data)} years of data")
         return growth_analysis

--- a/data/yearly_analysis.py
+++ b/data/yearly_analysis.py
@@ -55,9 +55,6 @@ class YearlyAnalyzer:
             # Get daily counts from the pre-processed data
             daily_counts = year_data.get('date_data', {}).get('daily_analysis', {}).get('daily_counts', {})
             
-            # Calculate target date (same day of year in the target year)
-            target_date = datetime(year, 1, 1) + timedelta(days=day_of_year - 1)
-            
             # Sum up CVEs from Jan 1 to the target day of year
             ytd_count = 0
             for day_num in range(1, day_of_year + 1):
@@ -79,7 +76,7 @@ class YearlyAnalyzer:
                     total_cves = year_data.get('total_cves', 0)
                     days_in_year = 366 if year % 4 == 0 else 365
                     return int((total_cves / days_in_year) * day_of_year)
-            except:
+            except (OSError, json.JSONDecodeError, TypeError, ValueError):
                 pass
             return 0
     

--- a/data/yearly_analysis.py
+++ b/data/yearly_analysis.py
@@ -16,8 +16,8 @@ from typing import Any
 # Logging setup
 try:
     from data.logging_config import get_logger
-except ImportError:
-    from logging_config import get_logger
+except ImportError:  # pragma: no cover - depends on how the module is imported
+    from logging_config import get_logger  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 
@@ -230,12 +230,12 @@ class YearlyAnalyzer:
         previous_year_data = next((year for year in all_year_data if year["year"] == self.current_year - 1), None)
         previous_year_count = previous_year_data["total_cves"] if previous_year_data else 0
 
-        yoy_growth = 0
+        yoy_growth: float = 0.0
         if previous_year_count > 0:
             yoy_growth = ((current_year_count - previous_year_count) / previous_year_count) * 100
 
         # Calculate average CVEs per day for current year
-        avg_cves_per_day = 0
+        avg_cves_per_day: float = 0.0
         if current_year_data:
             days_elapsed = datetime.now().timetuple().tm_yday
             avg_cves_per_day = current_year_count / days_elapsed if days_elapsed > 0 else 0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,6 +124,7 @@ def analyze(nvd_data, current_year_only=False):
     # Process data
     # Return analysis dict
 
+
 def main():
     """Command-line entry point."""
     # Load cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,10 @@ python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true
+# Without this, mypy aborts with "Source file found twice under different module
+# names" because data/ is importable both as `data.x` and as bare `x`. It was
+# failing that way before it checked anything, so the CI job never type-checked.
+explicit_package_bases = true
 exclude = [
     "data/cache/",
     "web/",
@@ -147,6 +151,20 @@ exclude = [
 
 [[tool.mypy.overrides]]
 module = "tests.*"
+ignore_errors = true
+
+# Ratchet list. These three modules carry 123 of the errors between them and are
+# exempt so the rest of the tree can be gated now rather than never. Remove an
+# entry once its module is clean; do not add to this list.
+[[tool.mypy.overrides]]
+module = [
+    "cve_v5_processor",
+    "cve_years",
+    "scoring_analysis",
+    "data.cve_v5_processor",
+    "data.cve_years",
+    "data.scoring_analysis",
+]
 ignore_errors = true
 
 # ============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,9 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "integration: marks tests as integration tests",
 ]
+# Without this, pytest-asyncio leaves async tests unrecognised and they error
+# out on a clean checkout, which trains everyone to ignore a red suite.
+asyncio_mode = "auto"
 
 # ============================================================================
 # Coverage Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,14 @@ ignore = [
     "ARG001", # Unused function argument (needed for callbacks)
     "ARG002", # Unused method argument
     "PTH123", # open() should use Path.open()
+    # The rules below are style preferences this codebase deliberately does not
+    # follow. They are listed explicitly rather than suppressed at the command
+    # line, so that `ruff check` can fail on everything else.
+    "SIM102", # Nested ifs are often clearer than one compound condition here,
+              # since the branches carry separate explanatory comments.
+    "SIM105", # try/except/pass reads more plainly than contextlib.suppress.
+    "TC003",  # Moving stdlib imports into TYPE_CHECKING blocks is ceremony
+              # that costs more readability than the import time it saves.
 ]
 
 # Allow autofix for all enabled rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,10 +149,6 @@ exclude = [
     "tests/",
 ]
 
-[[tool.mypy.overrides]]
-module = "tests.*"
-ignore_errors = true
-
 # Ratchet list. These three modules carry 123 of the errors between them and are
 # exempt so the rest of the tree can be gated now rather than never. Remove an
 # entry once its module is clean; do not add to this list.

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,9 +43,12 @@ pytest-asyncio>=0.21.0  # For async test support
 pytest-cov>=4.0.0  # For coverage reports
 
 # Code quality
-mypy>=1.0.0  # Type checking
+# Upper bounds matter here: ruff check and ruff format now gate CI, and both
+# tools change their rules between minor releases. Without a ceiling, a new
+# release turns main red with no change on our side. Raise these deliberately.
+mypy>=1.0.0,<3.0.0  # Type checking
 types-requests>=2.31.0  # Stubs so mypy can check requests call sites
-ruff>=0.1.0  # Fast Python linter (replaces flake8, black, isort)
+ruff>=0.16.0,<0.17.0  # Fast Python linter (replaces flake8, black, isort)
 
 # Pre-commit hooks
 pre-commit>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ pytest-cov>=4.0.0  # For coverage reports
 
 # Code quality
 mypy>=1.0.0  # Type checking
+types-requests>=2.31.0  # Stubs so mypy can check requests call sites
 ruff>=0.1.0  # Fast Python linter (replaces flake8, black, isort)
 
 # Pre-commit hooks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,17 +1,19 @@
 """
 Pytest configuration and shared fixtures for CVE.ICU tests.
 """
+
 from __future__ import annotations
 
 import json
 import sys
 import tempfile
 from collections.abc import Generator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import pytest
+
 
 # Add the data directory to the path for imports
 ROOT_DIR = Path(__file__).parent.parent
@@ -22,7 +24,8 @@ sys.path.insert(0, str(DATA_DIR))
 @pytest.fixture(autouse=True)
 def quiet_logging():
     """Automatically silence logging during tests to reduce noise."""
-    from logging_config import silence_for_tests, restore_logging
+    from logging_config import restore_logging, silence_for_tests
+
     silence_for_tests()
     yield
     restore_logging()
@@ -45,7 +48,7 @@ def sample_cve_record() -> dict[str, Any]:
             "assignerShortName": "mitre",
             "state": "PUBLISHED",
             "datePublished": "2024-06-15T10:30:00.000Z",
-            "dateUpdated": "2024-06-20T14:00:00.000Z"
+            "dateUpdated": "2024-06-20T14:00:00.000Z",
         },
         "containers": {
             "cna": {
@@ -53,27 +56,12 @@ def sample_cve_record() -> dict[str, Any]:
                     {
                         "vendor": "example_vendor",
                         "product": "example_product",
-                        "versions": [
-                            {"version": "1.0.0", "status": "affected"}
-                        ]
+                        "versions": [{"version": "1.0.0", "status": "affected"}],
                     }
                 ],
-                "descriptions": [
-                    {
-                        "lang": "en",
-                        "value": "A sample vulnerability description for testing."
-                    }
-                ],
+                "descriptions": [{"lang": "en", "value": "A sample vulnerability description for testing."}],
                 "problemTypes": [
-                    {
-                        "descriptions": [
-                            {
-                                "type": "CWE",
-                                "cweId": "CWE-79",
-                                "description": "Cross-site Scripting (XSS)"
-                            }
-                        ]
-                    }
+                    {"descriptions": [{"type": "CWE", "cweId": "CWE-79", "description": "Cross-site Scripting (XSS)"}]}
                 ],
                 "metrics": [
                     {
@@ -81,17 +69,13 @@ def sample_cve_record() -> dict[str, Any]:
                             "version": "3.1",
                             "baseScore": 7.5,
                             "baseSeverity": "HIGH",
-                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
                         }
                     }
                 ],
-                "references": [
-                    {
-                        "url": "https://example.com/advisory/CVE-2024-12345"
-                    }
-                ]
+                "references": [{"url": "https://example.com/advisory/CVE-2024-12345"}],
             }
-        }
+        },
     }
 
 
@@ -118,7 +102,7 @@ def sample_kev_data() -> set[str]:
 def sample_cna_analysis() -> dict[str, Any]:
     """Return a sample CNA analysis structure."""
     return {
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": datetime.now(UTC).isoformat(),
         "total_cnas": 5,
         "active_cnas": 4,
         "inactive_cnas": 1,
@@ -130,7 +114,7 @@ def sample_cna_analysis() -> dict[str, Any]:
                 "epss_high_count": 100,
                 "activity_status": "Active",
                 "cna_types": ["Program"],
-                "is_official": True
+                "is_official": True,
             },
             {
                 "name": "google",
@@ -139,9 +123,9 @@ def sample_cna_analysis() -> dict[str, Any]:
                 "epss_high_count": 45,
                 "activity_status": "Active",
                 "cna_types": ["Vendor"],
-                "is_official": True
-            }
-        ]
+                "is_official": True,
+            },
+        ],
     }
 
 
@@ -149,22 +133,10 @@ def sample_cna_analysis() -> dict[str, Any]:
 def sample_cvss_analysis() -> dict[str, Any]:
     """Return a sample CVSS analysis structure."""
     return {
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": datetime.now(UTC).isoformat(),
         "total_cves_with_cvss": 10000,
-        "total_by_version": {
-            "v3.1": 7000,
-            "v3.0": 2000,
-            "v2.0": 1000
-        },
-        "severity_distribution": {
-            "v3.1": {
-                "CRITICAL": 500,
-                "HIGH": 2000,
-                "MEDIUM": 3500,
-                "LOW": 900,
-                "NONE": 100
-            }
-        }
+        "total_by_version": {"v3.1": 7000, "v3.0": 2000, "v2.0": 1000},
+        "severity_distribution": {"v3.1": {"CRITICAL": 500, "HIGH": 2000, "MEDIUM": 3500, "LOW": 900, "NONE": 100}},
     }
 
 
@@ -176,25 +148,27 @@ def sample_year_data() -> dict[str, Any]:
         "total_cves": 5000,
         "date_data": {
             "monthly_distribution": {
-                "1": 400, "2": 380, "3": 450, "4": 420, "5": 410, "6": 430,
-                "7": 440, "8": 390, "9": 460, "10": 470, "11": 400, "12": 350
+                "1": 400,
+                "2": 380,
+                "3": 450,
+                "4": 420,
+                "5": 410,
+                "6": 430,
+                "7": 440,
+                "8": 390,
+                "9": 460,
+                "10": 470,
+                "11": 400,
+                "12": 350,
             },
             "daily_analysis": {
                 "total_days": 365,
                 "days_with_cves": 350,
                 "avg_cves_per_day": 13.7,
-                "max_cves_in_day": 85
-            }
+                "max_cves_in_day": 85,
+            },
         },
-        "cvss": {
-            "severity_distribution": {
-                "CRITICAL": 250,
-                "HIGH": 1250,
-                "MEDIUM": 2000,
-                "LOW": 1250,
-                "NONE": 250
-            }
-        }
+        "cvss": {"severity_distribution": {"CRITICAL": 250, "HIGH": 1250, "MEDIUM": 2000, "LOW": 1250, "NONE": 250}},
     }
 
 
@@ -202,11 +176,11 @@ def sample_year_data() -> dict[str, Any]:
 def mock_cve_list_dir(temp_dir: Path) -> Generator[Path, None, None]:
     """Create a mock CVE list directory structure with sample data."""
     cves_dir = temp_dir / "cvelistV5" / "cves"
-    
+
     # Create year/number directories
     year_dir = cves_dir / "2024" / "12xxx"
     year_dir.mkdir(parents=True)
-    
+
     # Create a sample CVE file
     cve_file = year_dir / "CVE-2024-12345.json"
     cve_data = {
@@ -215,21 +189,21 @@ def mock_cve_list_dir(temp_dir: Path) -> Generator[Path, None, None]:
             "assignerOrgId": "test-org-id",
             "assignerShortName": "test_cna",
             "state": "PUBLISHED",
-            "datePublished": "2024-06-15T10:30:00.000Z"
+            "datePublished": "2024-06-15T10:30:00.000Z",
         },
         "containers": {
             "cna": {
                 "affected": [{"vendor": "test_vendor", "product": "test_product"}],
                 "descriptions": [{"lang": "en", "value": "Test vulnerability"}],
                 "problemTypes": [{"descriptions": [{"type": "CWE", "cweId": "CWE-79"}]}],
-                "metrics": [{"cvssV3_1": {"baseScore": 7.5, "baseSeverity": "HIGH"}}]
+                "metrics": [{"cvssV3_1": {"baseScore": 7.5, "baseSeverity": "HIGH"}}],
             }
-        }
+        },
     }
-    
-    with open(cve_file, 'w') as f:
+
+    with open(cve_file, "w") as f:
         json.dump(cve_data, f)
-    
+
     yield temp_dir
 
 
@@ -244,8 +218,8 @@ CVE_YEAR_SCHEMA = {
         "cvss": {"type": "object"},
         "kev": {"type": "object"},
         "vendors": {"type": "object"},
-        "cwe": {"type": "object"}
-    }
+        "cwe": {"type": "object"},
+    },
 }
 
 CNA_ANALYSIS_SCHEMA = {
@@ -267,11 +241,11 @@ CNA_ANALYSIS_SCHEMA = {
                     "kev_count": {"type": "integer", "minimum": 0},
                     "epss_high_count": {"type": "integer", "minimum": 0},
                     "activity_status": {"type": "string"},
-                    "is_official": {"type": "boolean"}
-                }
-            }
-        }
-    }
+                    "is_official": {"type": "boolean"},
+                },
+            },
+        },
+    },
 }
 
 CVSS_ANALYSIS_SCHEMA = {
@@ -284,8 +258,8 @@ CVSS_ANALYSIS_SCHEMA = {
         "severity_distribution": {"type": "object"},
         "score_distribution": {"type": "object"},
         "kev_global_count": {"type": "integer"},
-        "kev_by_year": {"type": "object"}
-    }
+        "kev_by_year": {"type": "object"},
+    },
 }
 
 DATA_QUALITY_SCHEMA = {
@@ -302,11 +276,11 @@ DATA_QUALITY_SCHEMA = {
                 "org_name_matches": {"type": "integer"},
                 "normalized_matches": {"type": "integer"},
                 "partial_matches": {"type": "integer"},
-                "unmatched": {"type": "integer"}
-            }
+                "unmatched": {"type": "integer"},
+            },
         },
         "exact_matches": {"type": "array"},
         "case_mismatches": {"type": "array"},
-        "unmatched": {"type": "array"}
-    }
+        "unmatched": {"type": "array"},
+    },
 }

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -6,6 +6,7 @@ Provides in-memory implementations of protocols for unit testing.
 These fakes allow tests to run without actual file system access
 or HTTP requests, making tests faster and more deterministic.
 """
+
 from __future__ import annotations
 
 import json
@@ -15,146 +16,128 @@ from typing import Any
 
 class FakeHttpResponse:
     """Fake HTTP response for testing.
-    
+
     Simulates requests.Response interface with configurable
     status codes, content, and headers.
     """
-    
+
     def __init__(
         self,
         status_code: int = 200,
-        content: bytes = b'',
+        content: bytes = b"",
         headers: dict[str, str] | None = None,
-        json_data: Any | None = None
+        json_data: Any | None = None,
     ) -> None:
         self._status_code = status_code
         self._content = content
         self._headers = headers or {}
         self._json_data = json_data
-        
+
         # If json_data provided, serialize it to content
         if json_data is not None and not content:
-            self._content = json.dumps(json_data).encode('utf-8')
-    
+            self._content = json.dumps(json_data).encode("utf-8")
+
     @property
     def status_code(self) -> int:
         return self._status_code
-    
+
     @property
     def content(self) -> bytes:
         return self._content
-    
+
     @property
     def text(self) -> str:
-        return self._content.decode('utf-8')
-    
+        return self._content.decode("utf-8")
+
     @property
     def headers(self) -> dict[str, str]:
         return self._headers
-    
+
     def json(self) -> Any:
         if self._json_data is not None:
             return self._json_data
-        return json.loads(self._content.decode('utf-8'))
-    
+        return json.loads(self._content.decode("utf-8"))
+
     def raise_for_status(self) -> None:
         if self._status_code >= 400:
             raise FakeHttpError(f"HTTP {self._status_code}")
-    
+
     def iter_content(self, chunk_size: int = 1) -> Any:
         """Yield content in chunks."""
         for i in range(0, len(self._content), chunk_size):
-            yield self._content[i:i + chunk_size]
+            yield self._content[i : i + chunk_size]
 
 
 class FakeHttpError(Exception):
     """Fake HTTP error for testing error handling."""
+
     pass
 
 
 class FakeHttpClient:
     """Fake HTTP client for testing.
-    
+
     Provides configurable responses for specific URLs.
     Tracks request history for assertions.
-    
+
     Example:
         client = FakeHttpClient()
-        client.add_response('https://example.com/data.json', 
+        client.add_response('https://example.com/data.json',
                            json_data={'key': 'value'})
         response = client.get('https://example.com/data.json')
         assert response.json() == {'key': 'value'}
         assert client.request_count == 1
     """
-    
+
     def __init__(self) -> None:
         self._responses: dict[str, FakeHttpResponse] = {}
         self._request_history: list[dict[str, Any]] = []
         self._default_response: FakeHttpResponse | None = None
-    
+
     def add_response(
         self,
         url: str,
         *,
         status_code: int = 200,
-        content: bytes = b'',
+        content: bytes = b"",
         headers: dict[str, str] | None = None,
-        json_data: Any | None = None
+        json_data: Any | None = None,
     ) -> None:
         """Add a fake response for a specific URL."""
         self._responses[url] = FakeHttpResponse(
             status_code=status_code,
             content=content,
-            headers=headers or {'content-length': str(len(content))},
-            json_data=json_data
+            headers=headers or {"content-length": str(len(content))},
+            json_data=json_data,
         )
-    
-    def set_default_response(
-        self,
-        status_code: int = 200,
-        content: bytes = b'',
-        json_data: Any | None = None
-    ) -> None:
+
+    def set_default_response(self, status_code: int = 200, content: bytes = b"", json_data: Any | None = None) -> None:
         """Set default response for unregistered URLs."""
-        self._default_response = FakeHttpResponse(
-            status_code=status_code,
-            content=content,
-            json_data=json_data
-        )
-    
-    def get(
-        self,
-        url: str,
-        *,
-        timeout: int | None = None,
-        stream: bool = False
-    ) -> FakeHttpResponse:
+        self._default_response = FakeHttpResponse(status_code=status_code, content=content, json_data=json_data)
+
+    def get(self, url: str, *, timeout: int | None = None, stream: bool = False) -> FakeHttpResponse:
         """Perform fake HTTP GET request."""
-        self._request_history.append({
-            'url': url,
-            'timeout': timeout,
-            'stream': stream
-        })
-        
+        self._request_history.append({"url": url, "timeout": timeout, "stream": stream})
+
         if url in self._responses:
             return self._responses[url]
-        
+
         if self._default_response is not None:
             return self._default_response
-        
+
         # Return 404 for unregistered URLs
-        return FakeHttpResponse(status_code=404, content=b'Not Found')
-    
+        return FakeHttpResponse(status_code=404, content=b"Not Found")
+
     @property
     def request_count(self) -> int:
         """Number of requests made."""
         return len(self._request_history)
-    
+
     @property
     def request_history(self) -> list[dict[str, Any]]:
         """List of all requests made."""
         return self._request_history.copy()
-    
+
     def clear_history(self) -> None:
         """Clear request history."""
         self._request_history.clear()
@@ -162,164 +145,164 @@ class FakeHttpClient:
 
 class FakeDataReader:
     """Fake data reader for testing.
-    
+
     Provides in-memory file system simulation.
-    
+
     Example:
         reader = FakeDataReader()
         reader.add_json(Path('config.json'), {'debug': True})
         config = reader.read_json(Path('config.json'))
         assert config == {'debug': True}
     """
-    
+
     def __init__(self) -> None:
         self._files: dict[str, bytes] = {}
         self._json_files: dict[str, Any] = {}
-    
+
     def add_file(self, path: Path, content: bytes | str) -> None:
         """Add a fake file."""
         key = str(path)
         if isinstance(content, str):
-            self._files[key] = content.encode('utf-8')
+            self._files[key] = content.encode("utf-8")
         else:
             self._files[key] = content
-    
+
     def add_json(self, path: Path, data: Any) -> None:
         """Add a fake JSON file."""
         key = str(path)
         self._json_files[key] = data
-        self._files[key] = json.dumps(data).encode('utf-8')
-    
+        self._files[key] = json.dumps(data).encode("utf-8")
+
     def add_directory(self, path: Path, files: list[str]) -> None:
         """Add a fake directory with file names."""
         key = str(path)
         # Store directory marker and contents
-        self._files[f"{key}/__dir__"] = b''
+        self._files[f"{key}/__dir__"] = b""
         for file_name in files:
             file_path = path / file_name
             if str(file_path) not in self._files:
-                self._files[str(file_path)] = b''
-    
+                self._files[str(file_path)] = b""
+
     def read_json(self, path: Path) -> Any:
         """Read and parse JSON from fake file."""
         key = str(path)
         if key in self._json_files:
             return self._json_files[key]
         if key in self._files:
-            return json.loads(self._files[key].decode('utf-8'))
+            return json.loads(self._files[key].decode("utf-8"))
         raise FileNotFoundError(f"Fake file not found: {path}")
-    
+
     def read_text(self, path: Path) -> str:
         """Read text content from fake file."""
         key = str(path)
         if key in self._files:
-            return self._files[key].decode('utf-8')
+            return self._files[key].decode("utf-8")
         raise FileNotFoundError(f"Fake file not found: {path}")
-    
+
     def read_bytes(self, path: Path) -> bytes:
         """Read binary content from fake file."""
         key = str(path)
         if key in self._files:
             return self._files[key]
         raise FileNotFoundError(f"Fake file not found: {path}")
-    
+
     def exists(self, path: Path) -> bool:
         """Check if fake path exists."""
         key = str(path)
         return key in self._files or f"{key}/__dir__" in self._files
-    
+
     def list_dir(self, path: Path) -> list[Path]:
         """List fake directory contents."""
         key = str(path)
         result = []
         prefix = f"{key}/"
         seen = set()
-        
+
         for file_key in self._files:
             if file_key.startswith(prefix) and file_key != f"{key}/__dir__":
                 # Get the immediate child
-                remainder = file_key[len(prefix):]
-                child = remainder.split('/')[0]
+                remainder = file_key[len(prefix) :]
+                child = remainder.split("/")[0]
                 if child not in seen:
                     seen.add(child)
                     result.append(Path(path) / child)
-        
+
         return result
 
 
 class FakeDataWriter:
     """Fake data writer for testing.
-    
+
     Captures all writes in memory for assertions.
-    
+
     Example:
         writer = FakeDataWriter()
         writer.write_json(Path('output.json'), {'result': 42})
         assert writer.get_json(Path('output.json')) == {'result': 42}
     """
-    
+
     def __init__(self) -> None:
         self._files: dict[str, bytes] = {}
         self._directories: set[str] = set()
-    
+
     def write_json(self, path: Path, data: Any, indent: int = 2) -> None:
         """Write data as JSON to fake file."""
         key = str(path)
-        self._files[key] = json.dumps(data, indent=indent).encode('utf-8')
-    
+        self._files[key] = json.dumps(data, indent=indent).encode("utf-8")
+
     def write_text(self, path: Path, content: str) -> None:
         """Write text content to fake file."""
         key = str(path)
-        self._files[key] = content.encode('utf-8')
-    
+        self._files[key] = content.encode("utf-8")
+
     def write_bytes(self, path: Path, content: bytes) -> None:
         """Write binary content to fake file."""
         key = str(path)
         self._files[key] = content
-    
+
     def mkdir(self, path: Path, parents: bool = True, exist_ok: bool = True) -> None:
         """Create fake directory."""
         key = str(path)
         if key in self._directories and not exist_ok:
             raise FileExistsError(f"Directory exists: {path}")
         self._directories.add(key)
-    
+
     # Assertion helpers
-    
+
     def get_json(self, path: Path) -> Any:
         """Get written JSON data for assertions."""
         key = str(path)
         if key not in self._files:
             raise KeyError(f"File not written: {path}")
-        return json.loads(self._files[key].decode('utf-8'))
-    
+        return json.loads(self._files[key].decode("utf-8"))
+
     def get_text(self, path: Path) -> str:
         """Get written text content for assertions."""
         key = str(path)
         if key not in self._files:
             raise KeyError(f"File not written: {path}")
-        return self._files[key].decode('utf-8')
-    
+        return self._files[key].decode("utf-8")
+
     def get_bytes(self, path: Path) -> bytes:
         """Get written binary content for assertions."""
         key = str(path)
         if key not in self._files:
             raise KeyError(f"File not written: {path}")
         return self._files[key]
-    
+
     def was_written(self, path: Path) -> bool:
         """Check if file was written."""
         return str(path) in self._files
-    
+
     def was_directory_created(self, path: Path) -> bool:
         """Check if directory was created."""
         return str(path) in self._directories
-    
+
     @property
     def written_files(self) -> list[str]:
         """List all written file paths."""
         return list(self._files.keys())
-    
+
     @property
     def created_directories(self) -> list[str]:
         """List all created directories."""
@@ -328,44 +311,44 @@ class FakeDataWriter:
 
 class FakeCacheManager:
     """Fake cache manager for testing.
-    
+
     In-memory cache with configurable validity.
-    
+
     Example:
         cache = FakeCacheManager()
         cache.set('key', 'value', ttl_seconds=3600)
         assert cache.get('key') == 'value'
         assert cache.is_valid('key') == True
     """
-    
+
     def __init__(self, default_valid: bool = True) -> None:
         self._cache: dict[str, Any] = {}
         self._validity: dict[str, bool] = {}
         self._default_valid = default_valid
-    
+
     def is_valid(self, key: str) -> bool:
         """Check if cache entry is valid."""
         if key not in self._cache:
             return False
         return self._validity.get(key, self._default_valid)
-    
+
     def get(self, key: str) -> Any | None:
         """Get cached value."""
         return self._cache.get(key)
-    
+
     def set(self, key: str, value: Any, ttl_seconds: int | None = None) -> None:
         """Set cache value."""
         self._cache[key] = value
         self._validity[key] = True
-    
+
     def invalidate(self, key: str) -> None:
         """Invalidate cache entry."""
         self._validity[key] = False
-    
+
     def set_validity(self, key: str, valid: bool) -> None:
         """Manually set validity for testing."""
         self._validity[key] = valid
-    
+
     def clear(self) -> None:
         """Clear all cache entries."""
         self._cache.clear()
@@ -376,48 +359,49 @@ class FakeCacheManager:
 # Async Test Doubles
 # =============================================================================
 
+
 class FakeAsyncHttpResponse:
     """Fake async HTTP response for testing.
-    
+
     Simulates httpx.Response interface for async testing.
     """
-    
+
     def __init__(
         self,
         status_code: int = 200,
-        content: bytes = b'',
+        content: bytes = b"",
         headers: dict[str, str] | None = None,
-        json_data: Any | None = None
+        json_data: Any | None = None,
     ) -> None:
         self._status_code = status_code
         self._content = content
         self._headers = headers or {}
         self._json_data = json_data
-        
+
         if json_data is not None and not content:
-            self._content = json.dumps(json_data).encode('utf-8')
-    
+            self._content = json.dumps(json_data).encode("utf-8")
+
     @property
     def status_code(self) -> int:
         return self._status_code
-    
+
     @property
     def content(self) -> bytes:
         return self._content
-    
+
     @property
     def text(self) -> str:
-        return self._content.decode('utf-8')
-    
+        return self._content.decode("utf-8")
+
     @property
     def headers(self) -> dict[str, str]:
         return self._headers
-    
+
     def json(self) -> Any:
         if self._json_data is not None:
             return self._json_data
-        return json.loads(self._content.decode('utf-8'))
-    
+        return json.loads(self._content.decode("utf-8"))
+
     def raise_for_status(self) -> None:
         if self._status_code >= 400:
             raise FakeHttpError(f"HTTP {self._status_code}")
@@ -425,62 +409,53 @@ class FakeAsyncHttpResponse:
 
 class FakeAsyncHttpClient:
     """Fake async HTTP client for testing.
-    
+
     Provides configurable responses for async HTTP requests.
     Supports context manager protocol for async with.
-    
+
     Example:
         client = FakeAsyncHttpClient()
         client.add_response('https://example.com/api', json_data={'key': 'value'})
-        
+
         async with client:
             response = await client.get('https://example.com/api')
             assert response.json() == {'key': 'value'}
     """
-    
+
     def __init__(self) -> None:
         self._responses: dict[str, FakeAsyncHttpResponse] = {}
         self._request_history: list[dict[str, Any]] = []
         self._default_response: FakeAsyncHttpResponse | None = None
-    
+
     def add_response(
         self,
         url: str,
         *,
         status_code: int = 200,
-        content: bytes = b'',
+        content: bytes = b"",
         headers: dict[str, str] | None = None,
-        json_data: Any | None = None
+        json_data: Any | None = None,
     ) -> None:
         """Add a fake response for a specific URL."""
         self._responses[url] = FakeAsyncHttpResponse(
             status_code=status_code,
             content=content,
-            headers=headers or {'content-length': str(len(content))},
-            json_data=json_data
+            headers=headers or {"content-length": str(len(content))},
+            json_data=json_data,
         )
-    
-    def set_default_response(
-        self,
-        status_code: int = 200,
-        content: bytes = b'',
-        json_data: Any | None = None
-    ) -> None:
+
+    def set_default_response(self, status_code: int = 200, content: bytes = b"", json_data: Any | None = None) -> None:
         """Set default response for unregistered URLs."""
-        self._default_response = FakeAsyncHttpResponse(
-            status_code=status_code,
-            content=content,
-            json_data=json_data
-        )
-    
-    async def __aenter__(self) -> "FakeAsyncHttpClient":
+        self._default_response = FakeAsyncHttpResponse(status_code=status_code, content=content, json_data=json_data)
+
+    async def __aenter__(self) -> FakeAsyncHttpClient:
         """Async context manager entry."""
         return self
-    
+
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         """Async context manager exit."""
         pass
-    
+
     async def get(
         self,
         url: str,
@@ -488,30 +463,31 @@ class FakeAsyncHttpClient:
         timeout: int | None = None,
     ) -> FakeAsyncHttpResponse:
         """Perform fake async HTTP GET request."""
-        self._request_history.append({
-            'url': url,
-            'timeout': timeout,
-        })
-        
+        self._request_history.append(
+            {
+                "url": url,
+                "timeout": timeout,
+            }
+        )
+
         if url in self._responses:
             return self._responses[url]
-        
+
         if self._default_response is not None:
             return self._default_response
-        
-        return FakeAsyncHttpResponse(status_code=404, content=b'Not Found')
-    
+
+        return FakeAsyncHttpResponse(status_code=404, content=b"Not Found")
+
     @property
     def request_count(self) -> int:
         """Number of requests made."""
         return len(self._request_history)
-    
+
     @property
     def request_history(self) -> list[dict[str, Any]]:
         """List of all requests made."""
         return self._request_history.copy()
-    
+
     def clear_history(self) -> None:
         """Clear request history."""
         self._request_history.clear()
-

--- a/tests/test_async_downloader.py
+++ b/tests/test_async_downloader.py
@@ -4,87 +4,85 @@ Tests for async CVE data downloader.
 
 Tests parallel download functionality and async HTTP client behavior.
 """
+
 from __future__ import annotations
 
 import asyncio
 import json
+import sys
 from pathlib import Path
-from typing import Any
 
 import pytest
 
-import sys
-sys.path.insert(0, str(Path(__file__).parent.parent / 'data'))
 
-from tests.fakes import FakeAsyncHttpClient, FakeAsyncHttpResponse
+sys.path.insert(0, str(Path(__file__).parent.parent / "data"))
+
+from tests.fakes import FakeAsyncHttpClient
 
 
 class TestFakeAsyncHttpClient:
     """Tests for FakeAsyncHttpClient test double."""
-    
+
     @pytest.mark.asyncio
     async def test_returns_configured_response(self):
         """Fake async client returns configured response for URL."""
         client = FakeAsyncHttpClient()
-        client.add_response(
-            'https://example.com/api',
-            json_data={'status': 'ok'}
-        )
-        
+        client.add_response("https://example.com/api", json_data={"status": "ok"})
+
         async with client:
-            response = await client.get('https://example.com/api')
-        
+            response = await client.get("https://example.com/api")
+
         assert response.status_code == 200
-        assert response.json() == {'status': 'ok'}
-    
+        assert response.json() == {"status": "ok"}
+
     @pytest.mark.asyncio
     async def test_returns_404_for_unknown_url(self):
         """Fake async client returns 404 for unconfigured URLs."""
         client = FakeAsyncHttpClient()
-        
+
         async with client:
-            response = await client.get('https://unknown.com')
-        
+            response = await client.get("https://unknown.com")
+
         assert response.status_code == 404
-    
+
     @pytest.mark.asyncio
     async def test_tracks_request_history(self):
         """Fake async client tracks all requests made."""
         client = FakeAsyncHttpClient()
         client.set_default_response(json_data={})
-        
+
         async with client:
-            await client.get('https://example.com/a')
-            await client.get('https://example.com/b', timeout=30)
-        
+            await client.get("https://example.com/a")
+            await client.get("https://example.com/b", timeout=30)
+
         assert client.request_count == 2
-        assert client.request_history[0]['url'] == 'https://example.com/a'
-        assert client.request_history[1]['timeout'] == 30
-    
+        assert client.request_history[0]["url"] == "https://example.com/a"
+        assert client.request_history[1]["timeout"] == 30
+
     @pytest.mark.asyncio
     async def test_parallel_requests(self):
         """Fake async client handles parallel requests."""
         client = FakeAsyncHttpClient()
-        client.add_response('https://api1.com', json_data={'source': 'api1'})
-        client.add_response('https://api2.com', json_data={'source': 'api2'})
-        client.add_response('https://api3.com', json_data={'source': 'api3'})
-        
+        client.add_response("https://api1.com", json_data={"source": "api1"})
+        client.add_response("https://api2.com", json_data={"source": "api2"})
+        client.add_response("https://api3.com", json_data={"source": "api3"})
+
         async with client:
             responses = await asyncio.gather(
-                client.get('https://api1.com'),
-                client.get('https://api2.com'),
-                client.get('https://api3.com'),
+                client.get("https://api1.com"),
+                client.get("https://api2.com"),
+                client.get("https://api3.com"),
             )
-        
+
         assert len(responses) == 3
-        sources = {r.json()['source'] for r in responses}
-        assert sources == {'api1', 'api2', 'api3'}
+        sources = {r.json()["source"] for r in responses}
+        assert sources == {"api1", "api2", "api3"}
         assert client.request_count == 3
 
 
 class TestAsyncDownloaderIntegration:
     """Integration tests for AsyncCVEDownloader with fakes."""
-    
+
     @pytest.mark.asyncio
     async def test_download_result_dataclass(self):
         """DownloadResult dataclass works correctly."""
@@ -93,7 +91,7 @@ class TestAsyncDownloaderIntegration:
             from async_downloader import DownloadResult
         except ImportError:
             pytest.skip("async_downloader not available")
-        
+
         result = DownloadResult(
             source="test",
             success=True,
@@ -101,12 +99,12 @@ class TestAsyncDownloaderIntegration:
             size_bytes=1024,
             duration_seconds=0.5,
         )
-        
+
         assert result.source == "test"
         assert result.success is True
         assert result.size_bytes == 1024
         assert result.from_cache is False
-    
+
     @pytest.mark.asyncio
     async def test_async_downloader_initialization(self, tmp_path):
         """AsyncCVEDownloader initializes correctly."""
@@ -114,9 +112,9 @@ class TestAsyncDownloaderIntegration:
             from async_downloader import AsyncCVEDownloader
         except ImportError:
             pytest.skip("async_downloader not available")
-        
+
         downloader = AsyncCVEDownloader(cache_dir=tmp_path, quiet=True)
-        
+
         assert downloader.cache_dir == tmp_path
         assert downloader.nvd_file == tmp_path / "nvd.json"
         assert downloader.epss_cache_file == tmp_path / "epss_scores-current.csv.gz"
@@ -125,43 +123,43 @@ class TestAsyncDownloaderIntegration:
 
 class TestAsyncDownloaderCacheValidity:
     """Tests for cache validity checking."""
-    
+
     def test_cache_validity_for_missing_file(self, tmp_path):
         """Missing file should report invalid cache."""
         try:
             from async_downloader import AsyncCVEDownloader
         except ImportError:
             pytest.skip("async_downloader not available")
-        
+
         downloader = AsyncCVEDownloader(cache_dir=tmp_path, quiet=True)
-        
+
         assert downloader._is_cache_valid(tmp_path / "missing.json") is False
-    
+
     def test_cache_validity_for_existing_file(self, tmp_path):
         """Recent file should report valid cache."""
         try:
             from async_downloader import AsyncCVEDownloader
         except ImportError:
             pytest.skip("async_downloader not available")
-        
+
         test_file = tmp_path / "test.json"
         test_file.write_text('{"test": true}')
-        
+
         downloader = AsyncCVEDownloader(cache_dir=tmp_path, quiet=True)
-        
+
         assert downloader._is_cache_valid(test_file) is True
 
 
 class TestEpssKevParsing:
     """Tests for EPSS and KEV data parsing."""
-    
+
     def test_parse_kev_json(self, tmp_path):
         """KEV JSON parsing works correctly."""
         try:
             from async_downloader import AsyncCVEDownloader
         except ImportError:
             pytest.skip("async_downloader not available")
-        
+
         # Create fake KEV data
         kev_data = {
             "vulnerabilities": [
@@ -170,70 +168,72 @@ class TestEpssKevParsing:
                 {"cveID": "CVE-2023-9999"},
             ]
         }
-        
+
         downloader = AsyncCVEDownloader(cache_dir=tmp_path, quiet=True)
         downloader.kev_cache_file.write_text(json.dumps(kev_data))
-        
+
         result = downloader.parse_kev()
-        
+
         assert result is not None
         assert len(result) == 3
         assert "CVE-2024-0001" in result
         assert "CVE-2024-0002" in result
         assert "CVE-2023-9999" in result
-    
+
     def test_parse_kev_handles_missing_file(self, tmp_path):
         """KEV parsing handles missing file gracefully."""
         try:
             from async_downloader import AsyncCVEDownloader
         except ImportError:
             pytest.skip("async_downloader not available")
-        
+
         downloader = AsyncCVEDownloader(cache_dir=tmp_path, quiet=True)
-        
+
         result = downloader.parse_kev()
-        
+
         assert result is None
 
 
 class TestParallelDownloadBehavior:
     """Tests demonstrating parallel download behavior."""
-    
+
     @pytest.mark.asyncio
     async def test_gather_collects_all_results(self):
         """asyncio.gather collects results from parallel tasks."""
+
         async def fake_download(name: str, delay: float) -> dict:
             await asyncio.sleep(delay)
-            return {'source': name, 'success': True}
-        
+            return {"source": name, "success": True}
+
         # All downloads complete in ~0.1s total (parallel)
         # vs ~0.3s if sequential
         results = await asyncio.gather(
-            fake_download('nvd', 0.05),
-            fake_download('epss', 0.05),
-            fake_download('kev', 0.05),
+            fake_download("nvd", 0.05),
+            fake_download("epss", 0.05),
+            fake_download("kev", 0.05),
         )
-        
+
         assert len(results) == 3
-        sources = {r['source'] for r in results}
-        assert sources == {'nvd', 'epss', 'kev'}
-    
+        sources = {r["source"] for r in results}
+        assert sources == {"nvd", "epss", "kev"}
+
     @pytest.mark.asyncio
     async def test_gather_handles_exceptions(self):
         """asyncio.gather with return_exceptions handles failures."""
+
         async def succeed() -> str:
             return "ok"
-        
+
         async def fail() -> str:
             raise ValueError("download failed")
-        
+
         results = await asyncio.gather(
             succeed(),
             fail(),
             succeed(),
             return_exceptions=True,
         )
-        
+
         assert results[0] == "ok"
         assert isinstance(results[1], ValueError)
         assert results[2] == "ok"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -143,7 +143,7 @@ class TestBuildOutputValidity:
         years = data.get("years", {})
 
         # Convert keys to integers for comparison
-        year_ints = [int(y) for y in years.keys()]
+        year_ints = [int(y) for y in years]
 
         assert min(year_ints) == 1999, "Missing early years"
         assert max(year_ints) >= 2024, "Missing recent years"

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -20,29 +20,20 @@ TEMPLATES_DIR = ROOT_DIR / "templates"
 
 class TestBuildOutputExists:
     """Verify that expected build outputs exist."""
-    
-    @pytest.mark.skipif(
-        not WEB_DIR.exists(),
-        reason="Web directory not found - run build first"
-    )
+
+    @pytest.mark.skipif(not WEB_DIR.exists(), reason="Web directory not found - run build first")
     def test_web_directory_exists(self):
         """Web output directory should exist."""
         assert WEB_DIR.exists()
         assert WEB_DIR.is_dir()
-    
-    @pytest.mark.skipif(
-        not WEB_DATA_DIR.exists(),
-        reason="Web data directory not found - run build first"
-    )
+
+    @pytest.mark.skipif(not WEB_DATA_DIR.exists(), reason="Web data directory not found - run build first")
     def test_data_directory_exists(self):
         """Web data directory should exist."""
         assert WEB_DATA_DIR.exists()
         assert WEB_DATA_DIR.is_dir()
-    
-    @pytest.mark.skipif(
-        not WEB_DATA_DIR.exists(),
-        reason="Web data directory not found - run build first"
-    )
+
+    @pytest.mark.skipif(not WEB_DATA_DIR.exists(), reason="Web data directory not found - run build first")
     def test_core_json_files_exist(self):
         """Core JSON data files should exist."""
         required_files = [
@@ -55,15 +46,12 @@ class TestBuildOutputExists:
             "yearly_summary.json",
             "cve_all.json",
         ]
-        
+
         for filename in required_files:
             filepath = WEB_DATA_DIR / filename
             assert filepath.exists(), f"Missing required file: {filename}"
-    
-    @pytest.mark.skipif(
-        not WEB_DIR.exists(),
-        reason="Web directory not found - run build first"
-    )
+
+    @pytest.mark.skipif(not WEB_DIR.exists(), reason="Web directory not found - run build first")
     def test_html_pages_exist(self):
         """HTML pages should be generated."""
         required_pages = [
@@ -82,24 +70,21 @@ class TestBuildOutputExists:
             "data-quality.html",
             "about.html",
         ]
-        
+
         for page in required_pages:
             filepath = WEB_DIR / page
             assert filepath.exists(), f"Missing HTML page: {page}"
-    
-    @pytest.mark.skipif(
-        not (WEB_DIR / "static").exists(),
-        reason="Static directory not found - run build first"
-    )
+
+    @pytest.mark.skipif(not (WEB_DIR / "static").exists(), reason="Static directory not found - run build first")
     def test_static_assets_exist(self):
         """Static assets should be present."""
         static_dir = WEB_DIR / "static"
-        
+
         # Check CSS
         css_dir = static_dir / "css"
         assert css_dir.exists(), "CSS directory missing"
         assert (css_dir / "style.css").exists(), "Main stylesheet missing"
-        
+
         # Check JS directory exists
         js_dir = static_dir / "js"
         assert js_dir.exists(), "JS directory missing"
@@ -107,69 +92,62 @@ class TestBuildOutputExists:
 
 class TestBuildOutputValidity:
     """Verify that build outputs are valid and well-formed."""
-    
-    @pytest.mark.skipif(
-        not WEB_DATA_DIR.exists(),
-        reason="Web data directory not found - run build first"
-    )
+
+    @pytest.mark.skipif(not WEB_DATA_DIR.exists(), reason="Web data directory not found - run build first")
     def test_json_files_are_valid(self):
         """All JSON files should be valid JSON."""
         json_files = list(WEB_DATA_DIR.glob("*.json"))
-        
+
         assert len(json_files) > 0, "No JSON files found"
-        
+
         for json_file in json_files:
             try:
                 with open(json_file) as f:
                     json.load(f)
             except json.JSONDecodeError as e:
                 pytest.fail(f"Invalid JSON in {json_file.name}: {e}")
-    
-    @pytest.mark.skipif(
-        not WEB_DIR.exists(),
-        reason="Web directory not found - run build first"
-    )
+
+    @pytest.mark.skipif(not WEB_DIR.exists(), reason="Web directory not found - run build first")
     def test_html_files_have_content(self):
         """HTML files should not be empty."""
         html_files = list(WEB_DIR.glob("*.html"))
-        
+
         assert len(html_files) > 0, "No HTML files found"
-        
+
         for html_file in html_files:
             content = html_file.read_text()
             assert len(content) > 100, f"HTML file {html_file.name} appears empty"
-            assert "<!DOCTYPE html>" in content or "<html" in content, \
+            assert "<!DOCTYPE html>" in content or "<html" in content, (
                 f"HTML file {html_file.name} missing HTML structure"
-    
+            )
+
     @pytest.mark.skipif(
-        not (WEB_DATA_DIR / "cna_analysis.json").exists(),
-        reason="CNA analysis file not found - run build first"
+        not (WEB_DATA_DIR / "cna_analysis.json").exists(), reason="CNA analysis file not found - run build first"
     )
     def test_cna_analysis_has_data(self):
         """CNA analysis should have meaningful data."""
         with open(WEB_DATA_DIR / "cna_analysis.json") as f:
             data = json.load(f)
-        
+
         assert data.get("total_cnas", 0) > 100, "Too few CNAs - data may be incomplete"
         assert len(data.get("cna_list", [])) > 100, "CNA list too short"
-    
+
     @pytest.mark.skipif(
-        not (WEB_DATA_DIR / "yearly_summary.json").exists(),
-        reason="Yearly summary file not found - run build first"
+        not (WEB_DATA_DIR / "yearly_summary.json").exists(), reason="Yearly summary file not found - run build first"
     )
     def test_yearly_summary_has_all_years(self):
         """Yearly summary should contain all years from 1999."""
         with open(WEB_DATA_DIR / "yearly_summary.json") as f:
             data = json.load(f)
-        
+
         years = data.get("years", {})
-        
+
         # Convert keys to integers for comparison
         year_ints = [int(y) for y in years.keys()]
-        
+
         assert min(year_ints) == 1999, "Missing early years"
         assert max(year_ints) >= 2024, "Missing recent years"
-        
+
         # Should have reasonable total CVE counts
         total_cves = sum(y.get("total_cves", 0) for y in years.values())
         assert total_cves > 200000, f"Total CVEs ({total_cves}) seems too low"
@@ -177,81 +155,79 @@ class TestBuildOutputValidity:
 
 class TestTemplateValidity:
     """Verify that Jinja2 templates are valid."""
-    
+
     def test_templates_exist(self):
         """Template directory should have templates."""
         assert TEMPLATES_DIR.exists(), "Templates directory missing"
-        
+
         templates = list(TEMPLATES_DIR.glob("*.html"))
         assert len(templates) > 10, "Too few templates found"
-    
+
     def test_templates_extend_base(self):
         """Most templates should extend base.html."""
         templates = list(TEMPLATES_DIR.glob("*.html"))
-        
+
         for template in templates:
             if template.name == "base.html":
                 continue
-            
+
             content = template.read_text()
             # Most templates should extend base
             if "{% extends" in content:
-                assert "base.html" in content, \
-                    f"Template {template.name} extends something other than base.html"
-    
+                assert "base.html" in content, f"Template {template.name} extends something other than base.html"
+
     def test_base_template_has_required_blocks(self):
         """Base template should define required blocks."""
         base_path = TEMPLATES_DIR / "base.html"
         assert base_path.exists(), "base.html template missing"
-        
+
         content = base_path.read_text()
-        
+
         # Check for essential blocks
         assert "{% block content %}" in content, "Missing content block"
         assert "{% block title %}" in content, "Missing title block"
-        
+
         # Check for navigation
         assert "nav" in content.lower(), "Missing navigation"
-        
+
         # Check for footer
         assert "footer" in content.lower(), "Missing footer"
 
 
 class TestDataConsistency:
     """Verify data consistency across files."""
-    
+
     @pytest.mark.skipif(
         not all((WEB_DATA_DIR / f).exists() for f in ["cna_analysis.json", "cna_analysis_current_year.json"]),
-        reason="Required files not found - run build first"
+        reason="Required files not found - run build first",
     )
     def test_current_year_subset_of_all(self):
         """Current year CNAs should be a subset of all CNAs."""
         with open(WEB_DATA_DIR / "cna_analysis.json") as f:
             all_data = json.load(f)
-        
+
         with open(WEB_DATA_DIR / "cna_analysis_current_year.json") as f:
             current_data = json.load(f)
-        
+
         all_cna_names = {cna["name"] for cna in all_data.get("cna_list", [])}
         current_cna_names = {cna["name"] for cna in current_data.get("cna_list", [])}
-        
+
         # All current year CNAs should exist in the all-time list
         missing = current_cna_names - all_cna_names
         assert len(missing) == 0, f"Current year CNAs not in all-time: {missing}"
-    
+
     @pytest.mark.skipif(
-        not (WEB_DATA_DIR / "data_quality.json").exists(),
-        reason="Data quality file not found - run build first"
+        not (WEB_DATA_DIR / "data_quality.json").exists(), reason="Data quality file not found - run build first"
     )
     def test_data_quality_match_rate(self):
         """Data quality should show reasonable match rate."""
         with open(WEB_DATA_DIR / "data_quality.json") as f:
             data = json.load(f)
-        
+
         stats = data.get("stats", {})
         total = stats.get("total_cnas_in_analysis", 0)
         unmatched = stats.get("unmatched", 0)
-        
+
         if total > 0:
             match_rate = (total - unmatched) / total
             # Should match at least 80% of CNAs

--- a/tests/test_data_quality.py
+++ b/tests/test_data_quality.py
@@ -4,9 +4,11 @@ Tests for the data quality analysis module (rebuild_data_quality.py).
 Tests the CNAScorecard-style name matching logic.
 """
 
-import pytest
 import sys
 from pathlib import Path
+
+import pytest
+
 
 # Add data/scripts to path
 DATA_SCRIPTS_DIR = Path(__file__).parent.parent / "data" / "scripts"
@@ -15,51 +17,51 @@ sys.path.insert(0, str(DATA_SCRIPTS_DIR))
 
 class TestNameNormalization:
     """Test the name normalization function."""
-    
+
     def test_normalize_removes_spaces(self):
         """Normalization should remove spaces."""
         from rebuild_data_quality import normalize_name
-        
+
         assert normalize_name("Red Hat") == "redhat"
         assert normalize_name("Microsoft Corporation") == "microsoftcorporation"
-    
+
     def test_normalize_removes_hyphens(self):
         """Normalization should remove hyphens."""
         from rebuild_data_quality import normalize_name
-        
+
         assert normalize_name("F-Secure") == "fsecure"
         assert normalize_name("Hewlett-Packard") == "hewlettpackard"
-    
+
     def test_normalize_removes_underscores(self):
         """Normalization should remove underscores."""
         from rebuild_data_quality import normalize_name
-        
+
         assert normalize_name("some_vendor") == "somevendor"
-    
+
     def test_normalize_removes_dots(self):
         """Normalization should remove dots."""
         from rebuild_data_quality import normalize_name
-        
+
         assert normalize_name("example.com") == "examplecom"
-    
+
     def test_normalize_lowercases(self):
         """Normalization should lowercase."""
         from rebuild_data_quality import normalize_name
-        
+
         assert normalize_name("MICROSOFT") == "microsoft"
         assert normalize_name("Google") == "google"
-    
+
     def test_normalize_empty_string(self):
         """Normalization should handle empty strings."""
         from rebuild_data_quality import normalize_name
-        
+
         assert normalize_name("") == ""
         assert normalize_name(None) == ""
 
 
 class TestNameMatching:
     """Test the CNA name matching function."""
-    
+
     @pytest.fixture
     def official_cna_list(self):
         """Sample official CNA list."""
@@ -69,148 +71,145 @@ class TestNameMatching:
             {"shortName": "redhat", "organizationName": "Red Hat, Inc.", "cnaID": "CNA-003"},
             {"shortName": "f-secure", "organizationName": "F-Secure Corporation", "cnaID": "CNA-004"},
         ]
-    
+
     @pytest.fixture
     def lookup_maps(self, official_cna_list):
         """Build lookup maps from official CNA list."""
         from rebuild_data_quality import build_official_cna_lookups
+
         return build_official_cna_lookups(official_cna_list)
-    
+
     def test_exact_match(self, lookup_maps, official_cna_list):
         """Test exact shortName match."""
         from rebuild_data_quality import map_cve_name_to_official
-        
+
         short_map, org_map, all_names, norm_map = lookup_maps
-        
+
         result, match_type, confidence = map_cve_name_to_official(
             "microsoft", short_map, org_map, norm_map, official_cna_list
         )
-        
+
         assert result is not None
         assert result["shortName"] == "microsoft"
         assert match_type == "exact_short"
         assert confidence == "high"
-    
+
     def test_case_insensitive_match(self, lookup_maps, official_cna_list):
         """Test case-insensitive match."""
         from rebuild_data_quality import map_cve_name_to_official
-        
+
         short_map, org_map, all_names, norm_map = lookup_maps
-        
+
         result, match_type, confidence = map_cve_name_to_official(
             "MICROSOFT", short_map, org_map, norm_map, official_cna_list
         )
-        
+
         assert result is not None
         assert result["shortName"] == "microsoft"
         assert match_type == "case_short"
         assert confidence == "high"
-    
+
     def test_organization_name_match(self, lookup_maps, official_cna_list):
         """Test match via organization name."""
         from rebuild_data_quality import map_cve_name_to_official
-        
+
         short_map, org_map, all_names, norm_map = lookup_maps
-        
+
         result, match_type, confidence = map_cve_name_to_official(
             "Microsoft Corporation", short_map, org_map, norm_map, official_cna_list
         )
-        
+
         assert result is not None
         assert result["shortName"] == "microsoft"
         assert match_type in ("exact_org", "case_org")
         assert confidence == "high"
-    
+
     def test_normalized_match(self, lookup_maps, official_cna_list):
         """Test match via normalization (removing hyphens, spaces)."""
         from rebuild_data_quality import map_cve_name_to_official
-        
+
         short_map, org_map, all_names, norm_map = lookup_maps
-        
+
         # "fsecure" should match "f-secure" after normalization
         result, match_type, confidence = map_cve_name_to_official(
             "fsecure", short_map, org_map, norm_map, official_cna_list
         )
-        
+
         assert result is not None
         assert result["shortName"] == "f-secure"
         assert match_type == "normalized"
         assert confidence == "medium"
-    
+
     def test_partial_match(self, lookup_maps, official_cna_list):
         """Test partial/substring match."""
         from rebuild_data_quality import map_cve_name_to_official
-        
+
         short_map, org_map, all_names, norm_map = lookup_maps
-        
+
         # "microsoftinc" contains "microsoft"
         result, match_type, confidence = map_cve_name_to_official(
             "microsoftinc", short_map, org_map, norm_map, official_cna_list
         )
-        
+
         assert result is not None
         assert result["shortName"] == "microsoft"
         assert match_type == "partial"
         assert confidence == "low"
-    
+
     def test_no_match(self, lookup_maps, official_cna_list):
         """Test when no match is found."""
         from rebuild_data_quality import map_cve_name_to_official
-        
+
         short_map, org_map, all_names, norm_map = lookup_maps
-        
+
         result, match_type, confidence = map_cve_name_to_official(
             "unknownvendor123", short_map, org_map, norm_map, official_cna_list
         )
-        
+
         assert result is None
         assert match_type is None
         assert confidence is None
-    
+
     def test_empty_name(self, lookup_maps, official_cna_list):
         """Test handling of empty name."""
         from rebuild_data_quality import map_cve_name_to_official
-        
+
         short_map, org_map, all_names, norm_map = lookup_maps
-        
-        result, match_type, confidence = map_cve_name_to_official(
-            "", short_map, org_map, norm_map, official_cna_list
-        )
-        
+
+        result, match_type, confidence = map_cve_name_to_official("", short_map, org_map, norm_map, official_cna_list)
+
         assert result is None
         assert match_type is None
 
 
 class TestBuildLookups:
     """Test the lookup map building function."""
-    
+
     def test_build_lookups_creates_all_maps(self):
         """Verify all lookup maps are created."""
         from rebuild_data_quality import build_official_cna_lookups
-        
-        cna_list = [
-            {"shortName": "test", "organizationName": "Test Corp", "cnaID": "CNA-TEST"}
-        ]
-        
+
+        cna_list = [{"shortName": "test", "organizationName": "Test Corp", "cnaID": "CNA-TEST"}]
+
         short_map, org_map, all_names, norm_map = build_official_cna_lookups(cna_list)
-        
+
         assert "test" in short_map
         assert "Test Corp" in org_map
         assert "test" in all_names
         assert "testcorp" in norm_map  # normalized org name
-    
+
     def test_build_lookups_handles_missing_fields(self):
         """Verify handling of CNAs with missing fields."""
         from rebuild_data_quality import build_official_cna_lookups
-        
+
         cna_list = [
             {"shortName": "test1"},  # Missing organizationName
             {"organizationName": "Test Corp 2"},  # Missing shortName
             {"shortName": "", "organizationName": ""},  # Empty fields
         ]
-        
+
         # Should not raise
         short_map, org_map, all_names, norm_map = build_official_cna_lookups(cna_list)
-        
+
         assert "test1" in short_map
         assert "Test Corp 2" in org_map

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -312,7 +312,10 @@ class TestAsyncFunctionality:
     @pytest.mark.asyncio
     async def test_async_http_session_concept(self):
         """Test that httpx is available and can create async clients."""
-        import httpx
+        # httpx is an optional dependency: the downloader falls back to a
+        # sequential requests-based path without it. Skip rather than fail so a
+        # clean checkout is green.
+        httpx = pytest.importorskip("httpx")
         
         # Basic smoke test - module should be importable
         assert httpx is not None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,6 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import Mock, patch
 
 import pytest
 
@@ -20,8 +19,8 @@ pytestmark = pytest.mark.integration
 
 def strip_ansi(text: str) -> str:
     """Remove ANSI escape codes from text."""
-    ansi_pattern = re.compile(r'\x1b\[[0-9;]*m')
-    return ansi_pattern.sub('', text)
+    ansi_pattern = re.compile(r"\x1b\[[0-9;]*m")
+    return ansi_pattern.sub("", text)
 
 
 class TestCLIIntegration:
@@ -116,7 +115,7 @@ class TestBuildPipelineIntegration:
             "cna_analysis.json",
             "calendar_analysis.json",
         ]
-        
+
         for filename in expected_files:
             filepath = data_dir / filename
             if filepath.exists():
@@ -133,14 +132,14 @@ class TestBuildPipelineIntegration:
 
         year_files = list(data_dir.glob("cve_*.json"))
         year_files = [f for f in year_files if f.stem.startswith("cve_") and f.stem[4:].isdigit()]
-        
+
         if not year_files:
             pytest.skip("No year files available")
 
         for year_file in year_files[:5]:  # Check first 5
             with open(year_file) as f:
                 data = json.load(f)
-            
+
             # All year files should have these keys
             assert "total_cves" in data
             assert "year" in data
@@ -162,7 +161,7 @@ class TestBuildPipelineIntegration:
 
         # Yearly trend should be a list
         assert isinstance(data["yearly_trend"], list)
-        
+
         # Each trend entry should have year and count
         if data["yearly_trend"]:
             entry = data["yearly_trend"][0]
@@ -193,19 +192,19 @@ class TestEdgeCases:
     def test_builder_quiet_mode(self):
         """Test that quiet mode is properly set."""
         from build import CVESiteBuilder
-        
+
         builder = CVESiteBuilder(quiet=True)
         assert builder.quiet is True
-        
+
         builder = CVESiteBuilder(quiet=False)
         assert builder.quiet is False
 
     def test_builder_year_range_valid(self):
         """Test that builder has valid year range."""
         from build import CVESiteBuilder
-        
+
         builder = CVESiteBuilder(quiet=True)
-        
+
         # Should have years from 1999 to current year
         assert 1999 in builder.available_years
         assert builder.current_year >= 2024
@@ -214,15 +213,15 @@ class TestEdgeCases:
     def test_builder_paths_are_valid(self):
         """Test that builder paths are properly configured."""
         from build import CVESiteBuilder
-        
+
         builder = CVESiteBuilder(quiet=True)
-        
+
         # All paths should be Path objects
         assert isinstance(builder.web_dir, Path)
         assert isinstance(builder.data_dir, Path)
         assert isinstance(builder.templates_dir, Path)
         assert isinstance(builder.cache_dir, Path)
-        
+
         # Templates directory should exist
         assert builder.templates_dir.exists()
 
@@ -233,19 +232,17 @@ class TestDataValidation:
     def test_validate_data_counts_function_exists(self):
         """Test that validate_data_counts function is available."""
         from build import validate_data_counts
-        
+
         assert callable(validate_data_counts)
 
     def test_validation_with_mock_builder(self):
         """Test validation with a mock builder."""
-        from build import validate_data_counts, CVESiteBuilder
-        from pathlib import Path
-        import tempfile
-        import json
-        
+
+        from build import CVESiteBuilder, validate_data_counts
+
         # Create a mock builder with temp directory
         builder = CVESiteBuilder(quiet=True)
-        
+
         # If data directory exists and has files, validation should run
         if builder.data_dir.exists() and (builder.data_dir / "cve_all.json").exists():
             result = validate_data_counts(builder)
@@ -316,10 +313,10 @@ class TestAsyncFunctionality:
         # sequential requests-based path without it. Skip rather than fail so a
         # clean checkout is green.
         httpx = pytest.importorskip("httpx")
-        
+
         # Basic smoke test - module should be importable
         assert httpx is not None
-        
+
         # Test that we can reference async client types
-        assert hasattr(httpx, 'AsyncClient')
-        assert hasattr(httpx, 'Response')
+        assert hasattr(httpx, "AsyncClient")
+        assert hasattr(httpx, "Response")

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -7,267 +7,259 @@ Validates that:
 2. Test fakes provide expected behavior
 3. Protocol-based code can use either implementation
 """
+
 from __future__ import annotations
-
-import json
-from pathlib import Path
-from typing import TYPE_CHECKING
-
-import pytest
 
 # Import protocols
 import sys
-sys.path.insert(0, str(Path(__file__).parent.parent / 'data'))
+from pathlib import Path
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "data"))
 
 from protocols import (
-    HttpClient,
+    CacheManager,
     DataReader,
     DataWriter,
-    CacheManager,
     FileSystemDataReader,
     FileSystemDataWriter,
-    RequestsHttpClient,
+    HttpClient,
 )
 
 # Import fakes from tests directory
 from tests.fakes import (
-    FakeHttpClient,
-    FakeHttpResponse,
+    FakeCacheManager,
     FakeDataReader,
     FakeDataWriter,
-    FakeCacheManager,
+    FakeHttpClient,
 )
 
 
 class TestFakeHttpClient:
     """Tests for FakeHttpClient test double."""
-    
+
     def test_returns_configured_response(self):
         """Fake client returns configured response for URL."""
         client = FakeHttpClient()
-        client.add_response(
-            'https://example.com/api',
-            json_data={'status': 'ok'}
-        )
-        
-        response = client.get('https://example.com/api')
-        
+        client.add_response("https://example.com/api", json_data={"status": "ok"})
+
+        response = client.get("https://example.com/api")
+
         assert response.status_code == 200
-        assert response.json() == {'status': 'ok'}
-    
+        assert response.json() == {"status": "ok"}
+
     def test_returns_404_for_unknown_url(self):
         """Fake client returns 404 for unconfigured URLs."""
         client = FakeHttpClient()
-        
-        response = client.get('https://unknown.com')
-        
+
+        response = client.get("https://unknown.com")
+
         assert response.status_code == 404
-    
+
     def test_tracks_request_history(self):
         """Fake client tracks all requests made."""
         client = FakeHttpClient()
         client.set_default_response(json_data={})
-        
-        client.get('https://example.com/a')
-        client.get('https://example.com/b', timeout=30)
-        
+
+        client.get("https://example.com/a")
+        client.get("https://example.com/b", timeout=30)
+
         assert client.request_count == 2
-        assert client.request_history[0]['url'] == 'https://example.com/a'
-        assert client.request_history[1]['timeout'] == 30
-    
+        assert client.request_history[0]["url"] == "https://example.com/a"
+        assert client.request_history[1]["timeout"] == 30
+
     def test_raise_for_status_on_error(self):
         """Fake response raises on error status codes."""
         client = FakeHttpClient()
-        client.add_response('https://example.com/error', status_code=500)
-        
-        response = client.get('https://example.com/error')
-        
+        client.add_response("https://example.com/error", status_code=500)
+
+        response = client.get("https://example.com/error")
+
         with pytest.raises(Exception):
             response.raise_for_status()
-    
+
     def test_iter_content_yields_chunks(self):
         """Fake response yields content in chunks."""
         client = FakeHttpClient()
-        client.add_response(
-            'https://example.com/data',
-            content=b'Hello World'
-        )
-        
-        response = client.get('https://example.com/data')
+        client.add_response("https://example.com/data", content=b"Hello World")
+
+        response = client.get("https://example.com/data")
         chunks = list(response.iter_content(chunk_size=5))
-        
-        assert chunks == [b'Hello', b' Worl', b'd']
+
+        assert chunks == [b"Hello", b" Worl", b"d"]
 
 
 class TestFakeDataReader:
     """Tests for FakeDataReader test double."""
-    
+
     def test_reads_json_file(self):
         """Fake reader returns configured JSON data."""
         reader = FakeDataReader()
-        reader.add_json(Path('/data/config.json'), {'debug': True})
-        
-        data = reader.read_json(Path('/data/config.json'))
-        
-        assert data == {'debug': True}
-    
+        reader.add_json(Path("/data/config.json"), {"debug": True})
+
+        data = reader.read_json(Path("/data/config.json"))
+
+        assert data == {"debug": True}
+
     def test_reads_text_file(self):
         """Fake reader returns configured text content."""
         reader = FakeDataReader()
-        reader.add_file(Path('/data/readme.txt'), 'Hello World')
-        
-        content = reader.read_text(Path('/data/readme.txt'))
-        
-        assert content == 'Hello World'
-    
+        reader.add_file(Path("/data/readme.txt"), "Hello World")
+
+        content = reader.read_text(Path("/data/readme.txt"))
+
+        assert content == "Hello World"
+
     def test_reads_binary_file(self):
         """Fake reader returns configured binary content."""
         reader = FakeDataReader()
-        reader.add_file(Path('/data/image.png'), b'\x89PNG')
-        
-        content = reader.read_bytes(Path('/data/image.png'))
-        
-        assert content == b'\x89PNG'
-    
+        reader.add_file(Path("/data/image.png"), b"\x89PNG")
+
+        content = reader.read_bytes(Path("/data/image.png"))
+
+        assert content == b"\x89PNG"
+
     def test_exists_returns_true_for_added_files(self):
         """Fake reader reports existence correctly."""
         reader = FakeDataReader()
-        reader.add_file(Path('/exists.txt'), 'content')
-        
-        assert reader.exists(Path('/exists.txt')) is True
-        assert reader.exists(Path('/missing.txt')) is False
-    
+        reader.add_file(Path("/exists.txt"), "content")
+
+        assert reader.exists(Path("/exists.txt")) is True
+        assert reader.exists(Path("/missing.txt")) is False
+
     def test_raises_on_missing_file(self):
         """Fake reader raises FileNotFoundError for missing files."""
         reader = FakeDataReader()
-        
+
         with pytest.raises(FileNotFoundError):
-            reader.read_json(Path('/missing.json'))
-    
+            reader.read_json(Path("/missing.json"))
+
     def test_list_dir_returns_children(self):
         """Fake reader lists directory contents."""
         reader = FakeDataReader()
-        reader.add_directory(Path('/data'), ['a.json', 'b.json', 'c.txt'])
-        
-        contents = reader.list_dir(Path('/data'))
+        reader.add_directory(Path("/data"), ["a.json", "b.json", "c.txt"])
+
+        contents = reader.list_dir(Path("/data"))
         names = [p.name for p in contents]
-        
-        assert sorted(names) == ['a.json', 'b.json', 'c.txt']
+
+        assert sorted(names) == ["a.json", "b.json", "c.txt"]
 
 
 class TestFakeDataWriter:
     """Tests for FakeDataWriter test double."""
-    
+
     def test_captures_json_writes(self):
         """Fake writer captures JSON writes for assertions."""
         writer = FakeDataWriter()
-        
-        writer.write_json(Path('/output.json'), {'result': 42})
-        
-        assert writer.get_json(Path('/output.json')) == {'result': 42}
-        assert writer.was_written(Path('/output.json')) is True
-    
+
+        writer.write_json(Path("/output.json"), {"result": 42})
+
+        assert writer.get_json(Path("/output.json")) == {"result": 42}
+        assert writer.was_written(Path("/output.json")) is True
+
     def test_captures_text_writes(self):
         """Fake writer captures text writes for assertions."""
         writer = FakeDataWriter()
-        
-        writer.write_text(Path('/output.txt'), 'Hello World')
-        
-        assert writer.get_text(Path('/output.txt')) == 'Hello World'
-    
+
+        writer.write_text(Path("/output.txt"), "Hello World")
+
+        assert writer.get_text(Path("/output.txt")) == "Hello World"
+
     def test_captures_binary_writes(self):
         """Fake writer captures binary writes for assertions."""
         writer = FakeDataWriter()
-        
-        writer.write_bytes(Path('/output.bin'), b'\x00\x01\x02')
-        
-        assert writer.get_bytes(Path('/output.bin')) == b'\x00\x01\x02'
-    
+
+        writer.write_bytes(Path("/output.bin"), b"\x00\x01\x02")
+
+        assert writer.get_bytes(Path("/output.bin")) == b"\x00\x01\x02"
+
     def test_tracks_directory_creation(self):
         """Fake writer tracks directory creation."""
         writer = FakeDataWriter()
-        
-        writer.mkdir(Path('/new/dir'))
-        
-        assert writer.was_directory_created(Path('/new/dir')) is True
-        assert writer.was_directory_created(Path('/other')) is False
-    
+
+        writer.mkdir(Path("/new/dir"))
+
+        assert writer.was_directory_created(Path("/new/dir")) is True
+        assert writer.was_directory_created(Path("/other")) is False
+
     def test_lists_written_files(self):
         """Fake writer lists all written files."""
         writer = FakeDataWriter()
-        writer.write_text(Path('/a.txt'), 'a')
-        writer.write_text(Path('/b.txt'), 'b')
-        
+        writer.write_text(Path("/a.txt"), "a")
+        writer.write_text(Path("/b.txt"), "b")
+
         assert len(writer.written_files) == 2
 
 
 class TestFakeCacheManager:
     """Tests for FakeCacheManager test double."""
-    
+
     def test_stores_and_retrieves_values(self):
         """Fake cache stores and retrieves values."""
         cache = FakeCacheManager()
-        
-        cache.set('key', {'data': 'value'})
-        
-        assert cache.get('key') == {'data': 'value'}
-        assert cache.is_valid('key') is True
-    
+
+        cache.set("key", {"data": "value"})
+
+        assert cache.get("key") == {"data": "value"}
+        assert cache.is_valid("key") is True
+
     def test_returns_none_for_missing_keys(self):
         """Fake cache returns None for missing keys."""
         cache = FakeCacheManager()
-        
-        assert cache.get('missing') is None
-        assert cache.is_valid('missing') is False
-    
+
+        assert cache.get("missing") is None
+        assert cache.is_valid("missing") is False
+
     def test_invalidation_works(self):
         """Fake cache invalidation works."""
         cache = FakeCacheManager()
-        cache.set('key', 'value')
-        
-        cache.invalidate('key')
-        
-        assert cache.is_valid('key') is False
-        assert cache.get('key') == 'value'  # Data still there, just invalid
-    
+        cache.set("key", "value")
+
+        cache.invalidate("key")
+
+        assert cache.is_valid("key") is False
+        assert cache.get("key") == "value"  # Data still there, just invalid
+
     def test_manual_validity_control(self):
         """Fake cache allows manual validity control for testing."""
         cache = FakeCacheManager()
-        cache.set('key', 'value')
-        
-        cache.set_validity('key', False)
-        
-        assert cache.is_valid('key') is False
+        cache.set("key", "value")
+
+        cache.set_validity("key", False)
+
+        assert cache.is_valid("key") is False
 
 
 class TestProtocolConformance:
     """Tests that implementations conform to protocols."""
-    
+
     def test_fake_http_client_is_http_client(self):
         """FakeHttpClient conforms to HttpClient protocol."""
         client = FakeHttpClient()
         assert isinstance(client, HttpClient)
-    
+
     def test_fake_data_reader_is_data_reader(self):
         """FakeDataReader conforms to DataReader protocol."""
         reader = FakeDataReader()
         assert isinstance(reader, DataReader)
-    
+
     def test_fake_data_writer_is_data_writer(self):
         """FakeDataWriter conforms to DataWriter protocol."""
         writer = FakeDataWriter()
         assert isinstance(writer, DataWriter)
-    
+
     def test_fake_cache_manager_is_cache_manager(self):
         """FakeCacheManager conforms to CacheManager protocol."""
         cache = FakeCacheManager()
         assert isinstance(cache, CacheManager)
-    
+
     def test_filesystem_reader_is_data_reader(self):
         """FileSystemDataReader conforms to DataReader protocol."""
         reader = FileSystemDataReader()
         assert isinstance(reader, DataReader)
-    
+
     def test_filesystem_writer_is_data_writer(self):
         """FileSystemDataWriter conforms to DataWriter protocol."""
         writer = FileSystemDataWriter()
@@ -276,44 +268,44 @@ class TestProtocolConformance:
 
 class TestFileSystemIntegration:
     """Integration tests for FileSystem implementations with real files."""
-    
+
     def test_reader_reads_real_json(self, tmp_path):
         """FileSystemDataReader reads actual JSON files."""
-        test_file = tmp_path / 'test.json'
+        test_file = tmp_path / "test.json"
         test_file.write_text('{"key": "value"}')
-        
+
         reader = FileSystemDataReader()
         data = reader.read_json(test_file)
-        
-        assert data == {'key': 'value'}
-    
+
+        assert data == {"key": "value"}
+
     def test_writer_writes_real_json(self, tmp_path):
         """FileSystemDataWriter writes actual JSON files."""
-        test_file = tmp_path / 'output.json'
-        
+        test_file = tmp_path / "output.json"
+
         writer = FileSystemDataWriter()
-        writer.write_json(test_file, {'result': 42})
-        
+        writer.write_json(test_file, {"result": 42})
+
         # Verify with reader
         reader = FileSystemDataReader()
-        assert reader.read_json(test_file) == {'result': 42}
-    
+        assert reader.read_json(test_file) == {"result": 42}
+
     def test_reader_exists_check(self, tmp_path):
         """FileSystemDataReader checks file existence correctly."""
-        existing = tmp_path / 'exists.txt'
-        existing.write_text('content')
-        
+        existing = tmp_path / "exists.txt"
+        existing.write_text("content")
+
         reader = FileSystemDataReader()
-        
+
         assert reader.exists(existing) is True
-        assert reader.exists(tmp_path / 'missing.txt') is False
-    
+        assert reader.exists(tmp_path / "missing.txt") is False
+
     def test_writer_creates_directories(self, tmp_path):
         """FileSystemDataWriter creates directories."""
-        new_dir = tmp_path / 'new' / 'nested' / 'dir'
-        
+        new_dir = tmp_path / "new" / "nested" / "dir"
+
         writer = FileSystemDataWriter()
         writer.mkdir(new_dir)
-        
+
         assert new_dir.exists()
         assert new_dir.is_dir()

--- a/tests/test_protocols.py
+++ b/tests/test_protocols.py
@@ -34,6 +34,7 @@ from tests.fakes import (
     FakeDataReader,
     FakeDataWriter,
     FakeHttpClient,
+    FakeHttpError,
 )
 
 
@@ -77,7 +78,7 @@ class TestFakeHttpClient:
 
         response = client.get("https://example.com/error")
 
-        with pytest.raises(Exception):
+        with pytest.raises(FakeHttpError):
             response.raise_for_status()
 
     def test_iter_content_yields_chunks(self):

--- a/tests/test_refresh_fallback.py
+++ b/tests/test_refresh_fallback.py
@@ -4,6 +4,7 @@ A refresh that downloads nothing must never report success. Before the
 sequential fallback existed, a missing httpx made `build.py refresh --force`
 print a success message and exit 0 in about a second, having fetched nothing.
 """
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
@@ -23,17 +24,21 @@ def builder(tmp_path):
 class TestAsyncUnavailableFallback:
     def test_missing_httpx_falls_back_instead_of_claiming_success(self, builder):
         """The regression this file exists for."""
-        with patch.object(CVESiteBuilder, "verify_source_manifest", return_value=None), \
-             patch("build.AsyncCVEDownloader", side_effect=ImportError("httpx is required")), \
-             patch.object(CVESiteBuilder, "refresh_data_sync", return_value=True) as fallback:
+        with (
+            patch.object(CVESiteBuilder, "verify_source_manifest", return_value=None),
+            patch("build.AsyncCVEDownloader", side_effect=ImportError("httpx is required")),
+            patch.object(CVESiteBuilder, "refresh_data_sync", return_value=True) as fallback,
+        ):
             assert builder.refresh_data(force=True) is True
             fallback.assert_called_once()
             assert fallback.call_args.kwargs["force"] is True
 
     def test_fallback_failure_is_reported(self, builder):
-        with patch.object(CVESiteBuilder, "verify_source_manifest", return_value=None), \
-             patch("build.AsyncCVEDownloader", side_effect=ImportError("httpx is required")), \
-             patch.object(CVESiteBuilder, "refresh_data_sync", return_value=False):
+        with (
+            patch.object(CVESiteBuilder, "verify_source_manifest", return_value=None),
+            patch("build.AsyncCVEDownloader", side_effect=ImportError("httpx is required")),
+            patch.object(CVESiteBuilder, "refresh_data_sync", return_value=False),
+        ):
             assert builder.refresh_data(force=True) is False
 
 

--- a/tests/test_regression_guards.py
+++ b/tests/test_regression_guards.py
@@ -7,6 +7,7 @@ our own analysis code, which the producer cannot see.
 Keying note: everything here is publication-date bucketed, matching our own
 outputs. Manifest year_counts are CVE-ID keyed and are never compared to these.
 """
+
 from __future__ import annotations
 
 import json
@@ -54,40 +55,46 @@ def lenient_builder(builder):
 
 class TestVerifyNoRegression:
     def test_accepts_growth(self, builder):
-        with patch.object(CVESiteBuilder, "fetch_published_totals",
-                          return_value=published(1000, **{"2025": 600, "2026": 400})):
+        with patch.object(
+            CVESiteBuilder, "fetch_published_totals", return_value=published(1000, **{"2025": 600, "2026": 400})
+        ):
             builder.verify_no_regression(year_data(**{"2025": 600, "2026": 450}))
 
     def test_accepts_small_decrease_within_allowance(self, builder):
         """Genuine CVE withdrawals are a handful of records and must not fail."""
-        with patch.object(CVESiteBuilder, "fetch_published_totals",
-                          return_value=published(1000, **{"2025": 600, "2026": 400})):
+        with patch.object(
+            CVESiteBuilder, "fetch_published_totals", return_value=published(1000, **{"2025": 600, "2026": 400})
+        ):
             builder.verify_no_regression(year_data(**{"2025": 595, "2026": 400}))
 
     def test_rejects_total_regression_beyond_allowance(self, builder):
-        with patch.object(CVESiteBuilder, "fetch_published_totals",
-                          return_value=published(359880, **{"2025": 48154, "2026": 51675})):
+        with patch.object(
+            CVESiteBuilder, "fetch_published_totals", return_value=published(359880, **{"2025": 48154, "2026": 51675})
+        ):
             with pytest.raises(RuntimeError, match="total"):
                 builder.verify_no_regression(year_data(**{"2025": 48154, "2026": 51375}))
 
     def test_rejects_closed_year_regression(self, builder):
         """The 2026-06-29 shape: year 2024 lost 5,254 CVEs and got them back."""
-        with patch.object(CVESiteBuilder, "fetch_published_totals",
-                          return_value=published(100000, **{"2024": 39959, "2026": 60041})):
+        with patch.object(
+            CVESiteBuilder, "fetch_published_totals", return_value=published(100000, **{"2024": 39959, "2026": 60041})
+        ):
             with pytest.raises(RuntimeError, match="year 2024"):
                 builder.verify_no_regression(year_data(**{"2024": 34705, "2026": 70000}))
 
     def test_rejects_vanished_closed_year(self, builder):
         """The 2026-07-08 shape: year 1999 disappeared entirely."""
-        with patch.object(CVESiteBuilder, "fetch_published_totals",
-                          return_value=published(10000, **{"1999": 894, "2026": 9106})):
+        with patch.object(
+            CVESiteBuilder, "fetch_published_totals", return_value=published(10000, **{"1999": 894, "2026": 9106})
+        ):
             with pytest.raises(RuntimeError, match="year 1999"):
                 builder.verify_no_regression(year_data(**{"2026": 9106}))
 
     def test_current_year_decrease_is_not_a_closed_year_error(self, builder):
         """The current year is still accumulating; only the total covers it."""
-        with patch.object(CVESiteBuilder, "fetch_published_totals",
-                          return_value=published(1000, **{"2025": 600, "2026": 400})):
+        with patch.object(
+            CVESiteBuilder, "fetch_published_totals", return_value=published(1000, **{"2025": 600, "2026": 400})
+        ):
             # total stays healthy, current year dips slightly
             builder.verify_no_regression(year_data(**{"2025": 700, "2026": 395}))
 
@@ -98,8 +105,9 @@ class TestVerifyNoRegression:
 
     def test_accept_baseline_skips_check(self, builder):
         builder.accept_baseline = True
-        with patch.object(CVESiteBuilder, "fetch_published_totals",
-                          side_effect=AssertionError("should not be fetched")):
+        with patch.object(
+            CVESiteBuilder, "fetch_published_totals", side_effect=AssertionError("should not be fetched")
+        ):
             builder.verify_no_regression(year_data(**{"2026": 1}))
 
     def test_allowance_boundary(self, builder):
@@ -135,11 +143,15 @@ class TestVerifyDataFreshness:
 class TestSourceProvenance:
     def test_reports_age_and_source_fields(self, builder, tmp_path):
         when = datetime.now(UTC) - timedelta(hours=3)
-        (tmp_path / "cache_info.json").write_text(json.dumps({
-            "download_time": when.isoformat(),
-            "source_last_run": "2026-08-18T01:07:27.380633+00:00",
-            "source_cve_count": 378426,
-        }))
+        (tmp_path / "cache_info.json").write_text(
+            json.dumps(
+                {
+                    "download_time": when.isoformat(),
+                    "source_last_run": "2026-08-18T01:07:27.380633+00:00",
+                    "source_cve_count": 378426,
+                }
+            )
+        )
         builder.source_provenance.cache_clear()
         p = builder.source_provenance()
         assert p["source_cve_count"] == 378426
@@ -170,15 +182,14 @@ class TestGuardEnforcementMode:
     """
 
     def test_regression_warns_instead_of_raising_outside_ci(self, lenient_builder):
-        with patch.object(CVESiteBuilder, "fetch_published_totals",
-                          return_value=published(10000, **{"1999": 894, "2026": 9106})):
+        with patch.object(
+            CVESiteBuilder, "fetch_published_totals", return_value=published(10000, **{"1999": 894, "2026": 9106})
+        ):
             lenient_builder.verify_no_regression(year_data(**{"2026": 9106}))
 
     def test_stale_data_warns_instead_of_raising_outside_ci(self, lenient_builder):
         stale = datetime.now(UTC) - timedelta(days=53)
-        (lenient_builder.cache_dir / "cache_info.json").write_text(
-            json.dumps({"download_time": stale.isoformat()})
-        )
+        (lenient_builder.cache_dir / "cache_info.json").write_text(json.dumps({"download_time": stale.isoformat()}))
         lenient_builder.source_provenance.cache_clear()
         lenient_builder.verify_data_freshness()
 

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -10,14 +10,15 @@ import sys
 from pathlib import Path
 
 import pytest
-from jsonschema import validate, ValidationError
+from jsonschema import validate
+
 
 # Add tests directory to path for importing conftest schemas
 sys.path.insert(0, str(Path(__file__).parent))
 
 from conftest import (
-    CVE_YEAR_SCHEMA,
     CNA_ANALYSIS_SCHEMA,
+    CVE_YEAR_SCHEMA,
     CVSS_ANALYSIS_SCHEMA,
     DATA_QUALITY_SCHEMA,
 )
@@ -29,79 +30,74 @@ WEB_DATA_DIR = Path(__file__).parent.parent / "web" / "data"
 
 class TestSchemaValidation:
     """Test that generated JSON files conform to expected schemas."""
-    
+
     @pytest.mark.skipif(
-        not (WEB_DATA_DIR / "cna_analysis.json").exists(),
-        reason="CNA analysis file not found - run build first"
+        not (WEB_DATA_DIR / "cna_analysis.json").exists(), reason="CNA analysis file not found - run build first"
     )
     def test_cna_analysis_schema(self):
         """Validate cna_analysis.json against schema."""
         with open(WEB_DATA_DIR / "cna_analysis.json") as f:
             data = json.load(f)
-        
+
         # Validate against schema
         validate(instance=data, schema=CNA_ANALYSIS_SCHEMA)
-        
+
         # Additional assertions
         assert data["total_cnas"] > 0, "Should have at least one CNA"
         assert len(data["cna_list"]) > 0, "CNA list should not be empty"
         assert data["active_cnas"] + data["inactive_cnas"] == data["total_cnas"]
-    
+
     @pytest.mark.skipif(
-        not (WEB_DATA_DIR / "cvss_analysis.json").exists(),
-        reason="CVSS analysis file not found - run build first"
+        not (WEB_DATA_DIR / "cvss_analysis.json").exists(), reason="CVSS analysis file not found - run build first"
     )
     def test_cvss_analysis_schema(self):
         """Validate cvss_analysis.json against schema."""
         with open(WEB_DATA_DIR / "cvss_analysis.json") as f:
             data = json.load(f)
-        
+
         # Validate against schema
         validate(instance=data, schema=CVSS_ANALYSIS_SCHEMA)
-        
+
         # Additional assertions
         assert data["total_cves_with_cvss"] > 0, "Should have scored CVEs"
         assert len(data["severity_distribution"]) > 0, "Severity distribution should have entries"
-    
+
     @pytest.mark.skipif(
-        not (WEB_DATA_DIR / "data_quality.json").exists(),
-        reason="Data quality file not found - run build first"
+        not (WEB_DATA_DIR / "data_quality.json").exists(), reason="Data quality file not found - run build first"
     )
     def test_data_quality_schema(self):
         """Validate data_quality.json against schema."""
         with open(WEB_DATA_DIR / "data_quality.json") as f:
             data = json.load(f)
-        
+
         # Validate against schema
         validate(instance=data, schema=DATA_QUALITY_SCHEMA)
-        
+
         # Additional assertions
         stats = data["stats"]
         total_analyzed = stats["total_cnas_in_analysis"]
         matched = (
-            stats["exact_matches"] + 
-            stats["case_mismatches"] + 
-            stats["org_name_matches"] + 
-            stats["normalized_matches"] + 
-            stats["partial_matches"]
+            stats["exact_matches"]
+            + stats["case_mismatches"]
+            + stats["org_name_matches"]
+            + stats["normalized_matches"]
+            + stats["partial_matches"]
         )
         unmatched = stats["unmatched"]
-        
-        assert total_analyzed == matched + unmatched, \
-            "Total should equal matched + unmatched"
-    
+
+        assert total_analyzed == matched + unmatched, "Total should equal matched + unmatched"
+
     @pytest.mark.skipif(
-        not (WEB_DATA_DIR / "cve_2024.json").exists(),
-        reason="Year data file not found - run build first"
+        not (WEB_DATA_DIR / "cve_2024.json").exists(), reason="Year data file not found - run build first"
     )
     def test_year_data_schema(self):
         """Validate a sample year data file against schema."""
         with open(WEB_DATA_DIR / "cve_2024.json") as f:
             data = json.load(f)
-        
+
         # Validate against schema
         validate(instance=data, schema=CVE_YEAR_SCHEMA)
-        
+
         # Additional assertions
         assert data["year"] == 2024
         assert data["total_cves"] > 0
@@ -109,80 +105,77 @@ class TestSchemaValidation:
 
 class TestDataIntegrity:
     """Test data integrity and consistency across files."""
-    
+
     @pytest.mark.skipif(
-        not (WEB_DATA_DIR / "cna_analysis.json").exists(),
-        reason="CNA analysis file not found - run build first"
+        not (WEB_DATA_DIR / "cna_analysis.json").exists(), reason="CNA analysis file not found - run build first"
     )
     def test_cna_list_has_required_fields(self):
         """Verify all CNAs have required fields populated."""
         with open(WEB_DATA_DIR / "cna_analysis.json") as f:
             data = json.load(f)
-        
+
         for cna in data["cna_list"]:
-            assert "name" in cna, f"CNA missing 'name' field"
+            assert "name" in cna, "CNA missing 'name' field"
             assert "count" in cna, f"CNA {cna.get('name', 'unknown')} missing 'count'"
             assert cna["count"] >= 0, f"CNA {cna['name']} has negative count"
-    
+
     @pytest.mark.skipif(
-        not (WEB_DATA_DIR / "yearly_summary.json").exists(),
-        reason="Yearly summary file not found - run build first"
+        not (WEB_DATA_DIR / "yearly_summary.json").exists(), reason="Yearly summary file not found - run build first"
     )
     def test_yearly_summary_completeness(self):
         """Verify yearly summary contains all expected years."""
         with open(WEB_DATA_DIR / "yearly_summary.json") as f:
             data = json.load(f)
-        
+
         years = data.get("years", {})
-        
+
         # Should have data from 1999 to current year
         assert "1999" in years or 1999 in years, "Missing 1999 data"
         assert "2024" in years or 2024 in years, "Missing 2024 data"
-        
+
         # Each year should have required fields
         for year, year_data in years.items():
             assert "total_cves" in year_data, f"Year {year} missing total_cves"
             assert year_data["total_cves"] >= 0, f"Year {year} has negative CVE count"
-    
+
     @pytest.mark.skipif(
         not all((WEB_DATA_DIR / f).exists() for f in ["cna_analysis.json", "cve_all.json"]),
-        reason="Required files not found - run build first"
+        reason="Required files not found - run build first",
     )
     def test_cve_totals_reasonable(self):
         """Verify CVE totals are in reasonable ranges."""
         with open(WEB_DATA_DIR / "cna_analysis.json") as f:
             cna_data = json.load(f)
-        
+
         with open(WEB_DATA_DIR / "cve_all.json") as f:
             all_data = json.load(f)
-        
+
         # Total CVEs from CNA analysis
         cna_total = sum(cna["count"] for cna in cna_data["cna_list"])
-        
+
         # cve_all.json contains metadata with total
         all_total = all_data.get("total_cves", 0)
-        
+
         # Both should be in reasonable range (200K+ CVEs exist)
         assert cna_total > 200000, f"CNA total ({cna_total}) seems too low"
         assert all_total > 200000, f"All total ({all_total}) seems too low"
-        
+
         # They may differ due to data sources/timing, but should be same order of magnitude
         ratio = cna_total / all_total if all_total > 0 else 0
-        assert 0.8 <= ratio <= 1.2, \
-            f"CNA total ({cna_total}) differs significantly from cve_all ({all_total})"
+        assert 0.8 <= ratio <= 1.2, f"CNA total ({cna_total}) differs significantly from cve_all ({all_total})"
 
 
 class TestFixtureSchemas:
     """Test that fixtures conform to schemas (validates our test data)."""
-    
+
     def test_sample_cna_analysis_valid(self, sample_cna_analysis):
         """Verify sample CNA analysis fixture is valid."""
         validate(instance=sample_cna_analysis, schema=CNA_ANALYSIS_SCHEMA)
-    
+
     def test_sample_cvss_analysis_valid(self, sample_cvss_analysis):
         """Verify sample CVSS analysis fixture is valid."""
         validate(instance=sample_cvss_analysis, schema=CVSS_ANALYSIS_SCHEMA)
-    
+
     def test_sample_year_data_valid(self, sample_year_data):
         """Verify sample year data fixture is valid."""
         validate(instance=sample_year_data, schema=CVE_YEAR_SCHEMA)

--- a/tests/test_source_manifest.py
+++ b/tests/test_source_manifest.py
@@ -5,6 +5,7 @@ These tests cover the gates that stand between that manifest and a build:
 health (degraded / API fallback / completeness), regression against the last
 accepted snapshot, and integrity of the downloaded object.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -169,9 +170,7 @@ class TestVerifyDownloadAgainstManifest:
         d = CVEDataDownloader(cache_dir=real_cache, quiet=True, http_client=FakeHttpClient())
         payload = b"payload"
         d.cache_file.write_bytes(payload)
-        d.verify_download_against_manifest(
-            make_manifest(sha256=hashlib.sha256(payload).hexdigest()), len(payload)
-        )
+        d.verify_download_against_manifest(make_manifest(sha256=hashlib.sha256(payload).hexdigest()), len(payload))
 
 
 class TestStreamingHash:
@@ -182,9 +181,7 @@ class TestStreamingHash:
         payload = b"x" * (3 * 1024 * 1024)
         target.write_bytes(payload)
         d = CVEDataDownloader(cache_dir=tmp_path, quiet=True, http_client=FakeHttpClient())
-        assert d.calculate_file_hash_streaming(target, chunk_size=64 * 1024) == (
-            hashlib.sha256(payload).hexdigest()
-        )
+        assert d.calculate_file_hash_streaming(target, chunk_size=64 * 1024) == (hashlib.sha256(payload).hexdigest())
 
 
 class TestBaselineManifest:
@@ -204,9 +201,7 @@ class TestBaselineManifest:
 class TestPersistAcceptedManifest:
     def test_writes_manifest(self, tmp_path):
         writer = FakeDataWriter()
-        d = CVEDataDownloader(
-            cache_dir=tmp_path, quiet=True, http_client=FakeHttpClient(), data_writer=writer
-        )
+        d = CVEDataDownloader(cache_dir=tmp_path, quiet=True, http_client=FakeHttpClient(), data_writer=writer)
         manifest = make_manifest()
         d.persist_accepted_manifest(manifest)
         assert writer.get_json(d.manifest_file) == manifest


### PR DESCRIPTION
Six CI checks were written so they could never report a failure. This takes each to green and then removes the suppressor, so they gate for real.

```
ruff check . --exit-zero
ruff format --check . || true
mypy build.py data/*.py ... || true
pip-audit -r requirements.txt || true
python build.py validate --quiet || echo "Validation completed"
```

## What they were hiding

**mypy was never type-checking anything.** It aborted during module resolution with "Source file found twice under different module names", and the trailing `|| true` made that invisible. Once it could resolve, it reported 153 errors.

**Eight latent bugs**, all from rules already enabled in `pyproject.toml`:

- Five undefined names, four of them *inside exception handlers*, where the handler itself raises `NameError` and masks the original exception. Three rebuild scripts catch `json.JSONDecodeError` without importing `json`; `quick_build.py` catches `jinja2.TemplateError` while only importing names from `jinja2`, and that script runs in CI as the Quick build test step.
- `cna_mapping_restart.py` calls `logger.info` on its last line with no logger defined anywhere, so it would do all its work and then fail on the way out.
- Two bare `except:` clauses, now narrowed so `KeyboardInterrupt` and unrelated bugs are not swallowed.
- A duplicate dict key, a loop variable shadowing an import, and an unused variable.

**Two real bugs from mypy**, not just annotation gaps:

- `async_downloader` narrowed `asyncio.gather(return_exceptions=True)` results with `isinstance(result, Exception)`. `gather` yields `BaseException`, so a `CancelledError` would fall through and be stored as a successful `DownloadResult`.
- The `async_downloader` CLI passed `cache_dir=None`, but `cache_dir` is typed `Path` and goes through `Path()` in `__post_init__`, which would raise.

**Nine failing tests on a clean checkout.** `asyncio_mode` was never set, so async tests errored rather than ran. Now 149 passed, 1 skipped.

## Structure

Six commits, ordered so the mechanical churn is separable from the real changes:

1. the eight latent bug fixes
2. test suite green on a clean checkout
3. ruff autofix and formatter, 1,517 findings to 25, mechanical only
4. remaining lint to zero
5. mypy runs and passes
6. the suppressors come off

## Scope limits, deliberate

`cve_v5_processor`, `cve_years` and `scoring_analysis` hold 123 of the 153 mypy errors and are exempted through a ratchet list in `pyproject.toml`, so the other twelve modules gate now rather than never. `SIM102`, `SIM105` and `TC003` are added to the ruff ignore list as style preferences this codebase does not follow, listed there rather than passed at the command line so everything else can still fail.

`deploy.yml` also gains a real `build.py validate` gate between build and publish, moves to `setup-python@v5` with native pip caching, and drops the hand-rolled cache step.

## Verification

Every gate run locally exactly as CI runs it: ruff check, ruff format --check, mypy, pip-audit, pytest, and validate all pass. `pip-audit` reports no known vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)