### PR TITLE
Reconcile CNA vs cve_all by decomposition, not a fuzz factor

### DIFF
--- a/build.py
+++ b/build.py
@@ -12,6 +12,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import cache
 from pathlib import Path
@@ -111,6 +112,10 @@ class CVESiteBuilder:
         # the allowance was derived; it is deliberately much tighter than a
         # percentage band would be.
         self.published_totals_url: str = "https://cve.icu/data/cve_all.json"
+        # Count of non-rejected CVEs published before 1999, measured during the
+        # year-data pass and emitted into cve_all.json so validation can subtract
+        # a real number instead of guessing. See docs/COUNTING.md.
+        self.excluded_pre_1999: int | None = None
         self.regression_allowance: int = 10
         # A 3-hourly build should never be running on data a full day old.
         self.max_data_age_hours: float = 24.0
@@ -433,6 +438,13 @@ class CVESiteBuilder:
                 except (KeyError, json.JSONDecodeError, OSError) as e:
                     self.print_always(f"  ❌ Failed to process {year}: {e}")
                     continue
+
+            # The buckets are populated by now, so this is a cheap lookup rather
+            # than a second pass over the feed.
+            self.excluded_pre_1999 = analyzer.count_excluded_pre_1999()
+            self.print_verbose(
+                f"  📅 {self.excluded_pre_1999:,} non-rejected CVEs published pre-1999 (excluded from year files)"
+            )
 
             self.print_always(f"✅ Generated {len(all_year_data)} year data files")
             return all_year_data
@@ -970,6 +982,9 @@ class CVESiteBuilder:
             "peak_year": peak_year,
             "peak_count": peak_count,
             "yoy_growth_rate": round(yoy_growth, 1),
+            # Records this file deliberately omits, so downstream consumers can
+            # reconcile against V5-sourced totals without a magic number.
+            "excluded_pre_1999": self.excluded_pre_1999,
             "yearly_trend": yearly_data,
         }
 
@@ -1652,6 +1667,98 @@ def info() -> None:
         console.print("\n  [yellow]⚠️  No cache info found - run 'build --refresh-data'[/yellow]")
 
 
+# --- CNA vs cve_all reconciliation -------------------------------------------
+#
+# cve_all.json is assembled from the 1999+ year files (NVD-sourced);
+# cna_analysis.json counts every non-rejected cvelistV5 record. The gap between
+# them is two independent terms, and only one of them can indicate a problem:
+#
+#   1. Pre-1999 publications - legacy CVEs backdated to their original 1988-1998
+#      disclosure date. Frozen history: it does not grow with the corpus. The
+#      exact count is measured during the build and published as
+#      cve_all.json:excluded_pre_1999.
+#   2. NVD ingestion lag - cvelistV5 has a CVE the moment the CNA publishes it;
+#      NVD ingests behind. This scales with DAILY publication volume, not corpus
+#      size - one Oracle CPU day alone lands 1,100-1,400 CVEs.
+#
+# Bounding (2) is the only useful check here, but it used to be measured as
+# abs((1) + (2)) against a flat 1,000. The fixed 679-record offset ate two thirds
+# of that budget, leaving ~321 CVEs of lag headroom, and the first busy
+# publication day tipped it over (2026-08-25: diff 1,196, deploy failed).
+# Subtracting (1) explicitly restores the full budget to the term that varies.
+
+# Used only when cve_all.json predates the excluded_pre_1999 field. Measured
+# 2026-08-26 against the NVD feed; it moves only if NVD re-dates legacy records.
+PRE_1999_FALLBACK = 679
+
+# Largest single publication day observed through 2026-08 is 1,474 (2026-07-21,
+# Oracle CPU). Two consecutive days of that with no ingestion is a stalled NVD
+# feed worth failing the deploy over; less than that is NVD catching up normally.
+MAX_INGESTION_LAG = 3000
+
+# V5 leads NVD, always. NVD pulling ahead by more than a rounding margin means a
+# feed is wrong - a real bug the previous abs() comparison could not see.
+MAX_NVD_LEAD = 100
+
+
+@dataclass(frozen=True)
+class ReconciliationResult:
+    """Outcome of comparing the V5-sourced CNA total against NVD-sourced cve_all."""
+
+    ok: bool
+    lag: int
+    pre_1999: int
+    message: str
+
+
+def reconcile_cna_vs_year_totals(
+    repo_total: int,
+    cve_all_total: int,
+    excluded_pre_1999: int | None = None,
+) -> ReconciliationResult:
+    """Reconcile the CNA (V5) total against the cve_all (NVD, 1999+) total.
+
+    Subtracts the known pre-1999 offset, then bounds what remains - NVD
+    ingestion lag - in both directions. See the module comment above and
+    docs/COUNTING.md for where the thresholds come from.
+    """
+    pre_1999 = PRE_1999_FALLBACK if excluded_pre_1999 is None else excluded_pre_1999
+    lag = repo_total - cve_all_total - pre_1999
+
+    if lag < -MAX_NVD_LEAD:
+        return ReconciliationResult(
+            ok=False,
+            lag=lag,
+            pre_1999=pre_1999,
+            message=(
+                f"cve_all ({cve_all_total:,}) leads CNA data by {-lag:,} after the "
+                f"{pre_1999:,} pre-1999 offset - NVD should never be ahead of cvelistV5"
+            ),
+        )
+
+    if lag > MAX_INGESTION_LAG:
+        return ReconciliationResult(
+            ok=False,
+            lag=lag,
+            pre_1999=pre_1999,
+            message=(
+                f"NVD ingestion lag ({lag:,}) exceeds {MAX_INGESTION_LAG:,} - cvelistV5 "
+                f"has CVEs the NVD feed has not picked up (CNA {repo_total:,} vs "
+                f"cve_all {cve_all_total:,}, pre-1999 offset {pre_1999:,})"
+            ),
+        )
+
+    return ReconciliationResult(
+        ok=True,
+        lag=lag,
+        pre_1999=pre_1999,
+        message=(
+            f"CNA total ({repo_total:,}) reconciles with cve_all ({cve_all_total:,}) "
+            f"[pre-1999: {pre_1999:,}, NVD lag: {lag:,}]"
+        ),
+    )
+
+
 def validate_data_counts(builder: CVESiteBuilder) -> bool:
     """Validate that data counting is consistent across output files.
 
@@ -1703,15 +1810,21 @@ def validate_data_counts(builder: CVESiteBuilder) -> bool:
         else:
             logger.info(f"    ✅ CNA counts consistent: {cna_sum:,}")
 
-        # CNA and cve_all should now be close (both exclude REJECTED).
-        # Allow a small fixed floor plus a tiny percentage to absorb source drift
-        # as the overall CVE corpus grows over time.
-        diff = abs(repo_total - cve_all_total) if cve_all_file.exists() else 0
-        allowed_diff = max(1000, int(cve_all_total * 0.005))
-        if diff <= allowed_diff:
-            logger.info(f"    ✅ CNA total ({repo_total:,}) ≈ cve_all ({cve_all_total:,}) [diff: {diff}]")
-        else:
-            errors.append(f"CNA vs cve_all difference ({diff:,}) too large (expected <={allowed_diff:,})")
+        # Both sides exclude REJECTED, so the remaining gap is the pre-1999
+        # offset plus NVD ingestion lag. Subtract the former, bound the latter.
+        if cve_all_file.exists():
+            excluded_pre_1999 = cve_all.get("excluded_pre_1999")
+            if excluded_pre_1999 is None:
+                warnings.append(
+                    f"cve_all.json has no excluded_pre_1999 field; reconciling against the "
+                    f"{PRE_1999_FALLBACK:,} fallback. Rebuild to measure it."
+                )
+
+            reconciliation = reconcile_cna_vs_year_totals(repo_total, cve_all_total, excluded_pre_1999)
+            if reconciliation.ok:
+                logger.info(f"    ✅ {reconciliation.message}")
+            else:
+                errors.append(reconciliation.message)
     else:
         warnings.append("cna_analysis.json not found")
 

--- a/data/cve_years.py
+++ b/data/cve_years.py
@@ -763,6 +763,19 @@ class CVEYearsAnalyzer:
 
         return list(vendors)
 
+    def count_excluded_pre_1999(self) -> int:
+        """Count non-rejected CVEs whose publication date predates the CVE program.
+
+        These are legacy CVEs backdated to their original 1988-1998 disclosure
+        (e.g. CVE-1999-0001, published 1997-12-01). ``cve_all.json`` is assembled
+        from the 1999+ year files, so these records are dropped there, while
+        ``cna_analysis.json`` counts every non-rejected V5 record regardless of
+        date. Reporting the number lets validation subtract a *known* offset
+        instead of absorbing it into a tolerance. See docs/COUNTING.md.
+        """
+        self._ensure_year_buckets()
+        return sum(len(bucket) for year, bucket in self.year_cve_buckets.items() if year < 1999)
+
     def get_year_data(self, year: int) -> dict[str, Any]:
         """Main method to get processed data for a specific year"""
         current_year = datetime.now().year

--- a/docs/COUNTING.md
+++ b/docs/COUNTING.md
@@ -86,19 +86,40 @@ Total V5 files:       319,485
 
 ### CNA Total vs cve_all Total
 
-The CNA analysis and cve_all.json have a small difference (~728 CVEs). This is expected due to:
+`cna_analysis.json` (V5) always runs ahead of `cve_all.json` (NVD, 1999+). The gap is
+**two independent terms**, and they behave completely differently:
 
 ```text
-CNA total (V5):       ~303,297  (V5 repo, no rejected)
-cve_all total (NVD):  ~302,569  (NVD, no rejected, 1999+)
-Difference:               ~728
-
-Breakdown:
-- Pre-1999 CVEs:          ~679  (excluded from NVD year files)
-- Source variance:         ~49  (minor V5 vs NVD timing diff)
+gap = pre_1999_offset + nvd_ingestion_lag
 ```
 
-Both sources now consistently exclude REJECTED CVEs (~16,188).
+| Term | Size | Behaviour |
+|------|------|-----------|
+| **Pre-1999 offset** | 679 (measured 2026-08-26) | **Frozen.** Legacy CVEs backdated to their original 1988-1998 disclosure date (1997: 252, 1998: 246). `cve_all.json` is assembled from the 1999+ year files, so they are dropped there; `cna_analysis.json` counts every non-rejected V5 record. Does not grow with the corpus. |
+| **NVD ingestion lag** | 100-1,500, spiky | **Varies with _daily publication volume_, not corpus size.** cvelistV5 has a CVE the instant the CNA publishes; NVD ingests behind. One Oracle CPU day lands 1,100-1,400 CVEs at once. |
+
+Both sources consistently exclude REJECTED CVEs.
+
+The build measures the pre-1999 term rather than assuming it, and publishes it as
+`cve_all.json:excluded_pre_1999`. `reconcile_cna_vs_year_totals()` in `build.py`
+subtracts it and bounds only the lag term, in both directions:
+
+- **Lag > `MAX_INGESTION_LAG` (3,000)** — two heavy publication days with no ingestion.
+  The NVD feed has stalled. Fails the build.
+- **Lag < `-MAX_NVD_LEAD` (-100)** — NVD is *ahead* of cvelistV5, which cannot legitimately
+  happen. One of the feeds is wrong. Fails the build.
+
+#### Why not a single tolerance?
+
+This check previously compared `abs(CNA - cve_all)` against a flat `< 1000`, which measured
+both terms together. The fixed 679-record offset consumed two thirds of the budget, leaving
+only ~321 CVEs of headroom for the term that actually moves. On **2026-08-25** a busy but
+unremarkable publication day (787 CVEs, 327 of them one Chrome batch) pushed the gap to
+1,196 and failed the scheduled deploy.
+
+Widening the tolerance to a percentage of corpus size does not fix this — it scales the
+budget against a number that has no relationship to either term. Subtracting the known
+offset is what restores the full budget to the lag.
 
 ## Validation
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -250,6 +250,72 @@ class TestDataValidation:
             assert isinstance(result, bool)
 
 
+class TestCnaVsCveAllReconciliation:
+    """Tests for reconcile_cna_vs_year_totals().
+
+    Regression cover for the 2026-08-25 deploy failure: the old check compared
+    abs(CNA - cve_all) against a flat 1,000, so the permanent 679-record pre-1999
+    offset consumed most of the budget and a normal busy publication day
+    (diff 1,196) failed the build.
+    """
+
+    def test_real_2026_08_25_numbers_now_pass(self):
+        """The exact totals that broke the deploy should reconcile cleanly."""
+        from build import reconcile_cna_vs_year_totals
+
+        # diff was 1,196 = 679 pre-1999 + 517 NVD ingestion lag
+        result = reconcile_cna_vs_year_totals(repo_total=364_000, cve_all_total=362_804, excluded_pre_1999=679)
+
+        assert result.ok
+        assert result.lag == 517
+
+    def test_pre_1999_offset_does_not_consume_lag_budget(self):
+        """Growing the pre-1999 offset must not shrink the room for lag."""
+        from build import MAX_INGESTION_LAG, reconcile_cna_vs_year_totals
+
+        small = reconcile_cna_vs_year_totals(300_000 + MAX_INGESTION_LAG, 300_000, 0)
+        large = reconcile_cna_vs_year_totals(300_000 + MAX_INGESTION_LAG + 5_000, 300_000, 5_000)
+
+        assert small.ok and large.ok
+        assert small.lag == large.lag == MAX_INGESTION_LAG
+
+    def test_heavy_publication_day_passes(self):
+        """An Oracle-CPU-sized day of un-ingested CVEs is normal, not a failure."""
+        from build import reconcile_cna_vs_year_totals
+
+        # 2026-07-21 published 1,474 CVEs; NVD trailing a full such day is fine.
+        result = reconcile_cna_vs_year_totals(364_000 + 1_474, 364_000, excluded_pre_1999=0)
+        assert result.ok
+
+    def test_stalled_nvd_feed_fails(self):
+        """Lag beyond two heavy publication days means NVD has stopped ingesting."""
+        from build import MAX_INGESTION_LAG, reconcile_cna_vs_year_totals
+
+        result = reconcile_cna_vs_year_totals(364_000 + MAX_INGESTION_LAG + 1, 364_000, excluded_pre_1999=0)
+
+        assert not result.ok
+        assert "ingestion lag" in result.message
+
+    def test_nvd_leading_v5_fails(self):
+        """NVD ahead of cvelistV5 is impossible; the old abs() check was blind to it."""
+        from build import reconcile_cna_vs_year_totals
+
+        result = reconcile_cna_vs_year_totals(repo_total=360_000, cve_all_total=365_000, excluded_pre_1999=679)
+
+        assert not result.ok
+        assert "should never be ahead" in result.message
+
+    def test_missing_offset_uses_documented_fallback(self):
+        """A cve_all.json predating the field still reconciles via the constant."""
+        from build import PRE_1999_FALLBACK, reconcile_cna_vs_year_totals
+
+        result = reconcile_cna_vs_year_totals(364_000, 364_000 - PRE_1999_FALLBACK)
+
+        assert result.ok
+        assert result.pre_1999 == PRE_1999_FALLBACK
+        assert result.lag == 0
+
+
 class TestHistoricalYearCoverageGuard:
     """Tests for the truncated-feed guardrail (verify_historical_year_coverage)."""
 


### PR DESCRIPTION
## What broke

The scheduled deploy failed on **2026-08-25 21:21 UTC**:

```
❌ Validation errors:
   - CNA vs cve_all difference (1,196) too large (expected <1000)
```

It looked like a publication spike. It wasn't. That day published 787 CVEs — busy, but the 34th-busiest day of 2026. The largest single publisher was Chrome at 327 (a contiguous block, `CVE-2026-78891`→`79293`).

## Why it broke

`abs(CNA_total - cve_all_total)` sums **two unrelated terms**:

| Term | Size | Behaviour |
|---|---|---|
| Pre-1999 publications | **679** | **Frozen.** Legacy CVEs backdated to their 1988-1998 disclosure date. `cve_all.json` is built from the 1999+ year files so it drops them; `cna_analysis.json` counts every non-rejected V5 record. Does not grow. |
| NVD ingestion lag | 100-1,500, spiky | cvelistV5 has a CVE the instant the CNA publishes; NVD ingests behind. Scales with **daily publication volume**, not corpus size. |

1,196 = 679 + 517. Only the lag term can indicate a problem, but the frozen 679 was eating two thirds of the budget — leaving roughly **321 CVEs of real headroom**. Any busy day was going to trip it.

## Why the current fix isn't enough

#40e5e3296 raised the bar to `max(1000, cve_all_total * 0.005)`. That buys room but indexes it to a quantity related to neither term. At today's corpus it allows 1,820 total → **1,141 of lag**. Single-day volume already exceeds that:

- 2026-07-21 — 1,474 published (oracle 1,097)
- 2026-08-18 — 1,408 published (oracle 889, quarterly CPU)

If NVD trails by a day during the **October CPU**, `679 + ~1,400 = ~2,087 > 1,820` and it fails again.

## What this PR does

**Measures the offset instead of guessing it.** `CVEYearsAnalyzer.count_excluded_pre_1999()` reads it off the year buckets already built during the year-data pass (no second pass over the feed), and `build.py` publishes it as `cve_all.json:excluded_pre_1999`. Falls back to a documented constant with a warning when reading an older `cve_all.json`.

**Subtracts it, then bounds only the lag** — and does so **directionally**:

- `lag > MAX_INGESTION_LAG` (3,000 ≈ two heavy publication days) → NVD feed has stalled.
- `lag < -MAX_NVD_LEAD` (-100) → NVD is *ahead* of cvelistV5, which cannot legitimately happen. **The old `abs()` was blind to this failure mode entirely.**

**Makes it testable.** The math moves into a pure `reconcile_cna_vs_year_totals()`, so it can be exercised without a built site. Six regression tests cover the real 2026-08-25 numbers, a heavy publication day, a stalled feed, an inverted feed, and the missing-field fallback.

## Verification

`count_excluded_pre_1999()` against the live NVD cache returns **679**, with the per-year breakdown `{1988: 2, 1989: 3, 1990: 11, 1991: 15, 1992: 13, 1993: 13, 1994: 25, 1995: 25, 1996: 74, 1997: 252, 1998: 246}` — independently reproduced from a second, different NVD snapshot.

`python build.py validate` on current data:

```
✅ CNA total (365,021) reconciles with cve_all (364,194) [pre-1999: 679, NVD lag: 148]
⚠️  cve_all.json has no excluded_pre_1999 field; reconciling against the 679 fallback. Rebuild to measure it.
```

(The warning is the fallback path working as designed — `web/data` predates this change and will pick up the field on the next build.)

`ruff check` clean, `ruff format` clean, `mypy` clean, `pytest` 147 passed / 6 new. The 9 `test_async_downloader` failures are pre-existing on `main` (missing `pytest-asyncio` locally) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)